### PR TITLE
Add vkui prefix

### DIFF
--- a/components.json
+++ b/components.json
@@ -8,7 +8,7 @@
     "css": "src/index.css",
     "baseColor": "zinc",
     "cssVariables": true,
-    "prefix": ""
+    "prefix": "vkui"
   },
   "aliases": {
     "components": "@/components",

--- a/src/components/ThemeModeToggle.tsx
+++ b/src/components/ThemeModeToggle.tsx
@@ -15,9 +15,9 @@ export function ThemeModeToggle() {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost">
-          <SunIcon className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-          <MoonIcon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-          <span className="sr-only">Toggle theme</span>
+          <SunIcon className="vkui:h-[1.2rem] vkui:w-[1.2rem] vkui:scale-100 vkui:rotate-0 vkui:transition-all vkui:dark:scale-0 vkui:dark:-rotate-90" />
+          <MoonIcon className="vkui:absolute vkui:h-[1.2rem] vkui:w-[1.2rem] vkui:scale-0 vkui:rotate-90 vkui:transition-all vkui:dark:scale-100 vkui:dark:rotate-0" />
+          <span className="vkui:sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -44,19 +44,19 @@ export function ThemeProvider({
 
     const root = window.document.documentElement;
 
-    root.classList.remove("light", "dark");
+    root.classList.remove("vkui:light", "vkui:dark");
 
     if (theme === "system") {
       const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
         .matches
-        ? "dark"
-        : "light";
+        ? "vkui:dark"
+        : "vkui:light";
 
       root.classList.add(systemTheme);
       return;
     }
 
-    root.classList.add(theme);
+    root.classList.add(`vkui:${theme}`);
   }, [theme, mounted]);
 
   const value = {
@@ -74,6 +74,10 @@ export function ThemeProvider({
           : "light"
         : theme,
   };
+
+  useEffect(() => {
+    value.setTheme(defaultTheme);
+  }, [defaultTheme]);
 
   return (
     <ThemeProviderContext.Provider {...props} value={value}>

--- a/src/components/elements/AudioOutput.tsx
+++ b/src/components/elements/AudioOutput.tsx
@@ -24,10 +24,10 @@ export const AudioOutput: React.FC<AudioOutputProps> = ({ className }) => {
   const id = useId();
 
   return (
-    <div className="flex items-center gap-4">
+    <div className="vkui:flex vkui:items-center vkui:gap-4">
       <label
         htmlFor={id}
-        className="text-sm font-medium text-muted-foreground whitespace-nowrap"
+        className="vkui:text-sm vkui:font-medium vkui:text-muted-foreground vkui:whitespace-nowrap"
       >
         Audio Output
       </label>
@@ -35,7 +35,7 @@ export const AudioOutput: React.FC<AudioOutputProps> = ({ className }) => {
         value={selectedSpeaker?.deviceId || ""}
         onValueChange={handleDeviceChange}
       >
-        <SelectTrigger id={id} className={cn("border-none w-full", className)}>
+        <SelectTrigger id={id} className={cn("vkui:border-none vkui:w-full", className)}>
           <SelectValue placeholder="Select a speaker" />
         </SelectTrigger>
         <SelectContent align="end">

--- a/src/components/elements/ClientStatus.tsx
+++ b/src/components/elements/ClientStatus.tsx
@@ -29,8 +29,8 @@ export const ClientStatus: React.FC = () => {
       data={{
         Client: (
           <span
-            className={cn("uppercase", {
-              "text-emerald-500":
+            className={cn("vkui:uppercase", {
+              "vkui:text-emerald-500":
                 transportState === "connected" || transportState === "ready",
             })}
           >
@@ -38,9 +38,9 @@ export const ClientStatus: React.FC = () => {
           </span>
         ),
         Agent: agentConnecting ? (
-          <span className="uppercase">Connecting...</span>
+          <span className="vkui:uppercase">Connecting...</span>
         ) : isBotConnected ? (
-          <span className="text-emerald-500 uppercase">Connected</span>
+          <span className="vkui:text-emerald-500 vkui:uppercase">Connected</span>
         ) : (
           "---"
         ),

--- a/src/components/elements/ConnectButton.tsx
+++ b/src/components/elements/ConnectButton.tsx
@@ -24,7 +24,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
         return {
           children: "Connect",
           variant: "default",
-          className: "bg-green-600 hover:bg-green-700",
+          className: "vkui:bg-green-600 vkui:hover:bg-green-700",
         };
       case "authenticating":
       case "connecting":
@@ -36,7 +36,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
         return {
           children: "Connect",
           variant: "default",
-          className: "bg-green-600 hover:bg-green-700",
+          className: "vkui:bg-green-600 vkui:hover:bg-green-700",
         };
     }
   };

--- a/src/components/elements/Conversation.tsx
+++ b/src/components/elements/Conversation.tsx
@@ -60,21 +60,21 @@ export const Conversation: React.FC = () => {
 
   if (messages.length > 0) {
     return (
-      <div ref={scrollRef} className="h-full overflow-y-auto p-4">
-        <div className="grid grid-cols-[min-content_1fr] gap-x-4 gap-y-2">
+      <div ref={scrollRef} className="vkui:h-full vkui:overflow-y-auto vkui:p-4">
+        <div className="vkui:grid vkui:grid-cols-[min-content_1fr] vkui:gap-x-4 vkui:gap-y-2">
           {messages.map((message, index) => (
             <Fragment key={index}>
               <div
-                className={cn("font-semibold font-mono text-xs leading-6", {
-                  "text-blue-500": message.role === "user",
-                  "text-purple-500": message.role === "assistant",
+                className={cn("vkui:font-semibold vkui:font-mono vkui:text-xs vkui:leading-6", {
+                  "vkui:text-blue-500": message.role === "user",
+                  "vkui:text-purple-500": message.role === "assistant",
                 })}
               >
                 {message.role}
               </div>
-              <div className="flex flex-col gap-2">
+              <div className="vkui:flex vkui:flex-col vkui:gap-2">
                 {message.content || <Thinking />}
-                <div className="self-end text-xs text-gray-500 mb-1">
+                <div className="vkui:self-end vkui:text-xs vkui:text-gray-500 vkui:mb-1">
                   {new Date(message.createdAt).toLocaleTimeString()}
                 </div>
               </div>
@@ -87,8 +87,8 @@ export const Conversation: React.FC = () => {
 
   if (isConnecting) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-muted-foreground text-sm">
+      <div className="vkui:flex vkui:items-center vkui:justify-center vkui:h-full">
+        <div className="vkui:text-muted-foreground vkui:text-sm">
           Connecting to agent...
         </div>
       </div>
@@ -97,12 +97,12 @@ export const Conversation: React.FC = () => {
 
   if (!isConnected) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-center p-4">
-          <div className="text-muted-foreground mb-2">
+      <div className="vkui:flex vkui:items-center vkui:justify-center vkui:h-full">
+        <div className="vkui:text-center vkui:p-4">
+          <div className="vkui:text-muted-foreground vkui:mb-2">
             Not connected to agent
           </div>
-          <p className="text-sm text-muted-foreground max-w-md">
+          <p className="vkui:text-sm vkui:text-muted-foreground vkui:max-w-md">
             Connect to an agent to see conversation messages in real-time.
           </p>
         </div>
@@ -111,8 +111,8 @@ export const Conversation: React.FC = () => {
   }
 
   return (
-    <div className="flex items-center justify-center h-full">
-      <div className="text-muted-foreground text-sm">
+    <div className="vkui:flex vkui:items-center vkui:justify-center vkui:h-full">
+      <div className="vkui:text-muted-foreground vkui:text-sm">
         Waiting for messages...
       </div>
     </div>

--- a/src/components/elements/CopyText.tsx
+++ b/src/components/elements/CopyText.tsx
@@ -33,15 +33,15 @@ export const CopyText: React.FC<CopyTextProps> = ({
   };
 
   return (
-    <div className={cn("flex items-center overflow-hidden w-full", className)}>
-      <span className="truncate min-w-0">{text}</span>
+    <div className={cn("vkui:flex vkui:items-center vkui:overflow-hidden vkui:w-full", className)}>
+      <span className="vkui:truncate vkui:min-w-0">{text}</span>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               variant="ghost"
               size="icon-sm"
-              className="flex-none"
+              className="vkui:flex-none"
               onClick={copyToClipboard}
               aria-label="Copy to clipboard"
             >

--- a/src/components/elements/DataList.tsx
+++ b/src/components/elements/DataList.tsx
@@ -8,12 +8,12 @@ interface DataListProps {
 const DataList: React.FC<DataListProps> = ({ data, className = "" }) => {
   return (
     <dl
-      className={`text-sm grid grid-cols-[1fr_2fr] gap-2 items-center ${className}`}
+      className={`vkui:text-sm vkui:grid vkui:grid-cols-[1fr_2fr] vkui:gap-2 vkui:items-center ${className}`}
     >
       {Object.entries(data).map(([key, value]) => (
         <React.Fragment key={key}>
-          <dt className="text-muted-foreground">{key}</dt>
-          <dd className="text-right font-mono text-xs min-w-0 truncate">
+          <dt className="vkui:text-muted-foreground">{key}</dt>
+          <dd className="vkui:text-right vkui:font-mono vkui:text-xs vkui:min-w-0 vkui:truncate">
             {value}
           </dd>
         </React.Fragment>

--- a/src/components/elements/Metrics.tsx
+++ b/src/components/elements/Metrics.tsx
@@ -177,32 +177,32 @@ export const Metrics: React.FC = () => {
 
   if (hasMetrics || hasTokenMetrics) {
     return (
-      <div className="@container/metrics grid gap-6 items-start p-4 max-h-full overflow-auto">
+      <div className="vkui:@container/metrics vkui:grid vkui:gap-6 vkui:items-start vkui:p-4 vkui:max-h-full vkui:overflow-auto">
         {hasTokenMetrics && (
           <>
-            <h2 className="text-xl font-semibold">Token Usage</h2>
-            <div className="grid grid-cols-1 @xl/metrics:grid-cols-2 @3xl/metrics:grid-cols-3 gap-4">
-              <div className="bg-card rounded-md p-3 shadow-sm">
-                <div className="text-sm text-muted-foreground">
+            <h2 className="vkui:text-xl vkui:font-semibold">Token Usage</h2>
+            <div className="vkui:grid vkui:grid-cols-1 vkui:@xl/metrics:grid-cols-2 vkui:@3xl/metrics:grid-cols-3 vkui:gap-4">
+              <div className="vkui:bg-card vkui:rounded-md vkui:p-3 vkui:shadow-sm">
+                <div className="vkui:text-sm vkui:text-muted-foreground">
                   Prompt Tokens
                 </div>
-                <div className="text-2xl font-medium">
+                <div className="vkui:text-2xl vkui:font-medium">
                   {tokenMetrics.prompt_tokens}
                 </div>
               </div>
-              <div className="bg-card rounded-md p-3 shadow-sm">
-                <div className="text-sm text-muted-foreground">
+              <div className="vkui:bg-card vkui:rounded-md vkui:p-3 vkui:shadow-sm">
+                <div className="vkui:text-sm vkui:text-muted-foreground">
                   Completion Tokens
                 </div>
-                <div className="text-2xl font-medium">
+                <div className="vkui:text-2xl vkui:font-medium">
                   {tokenMetrics.completion_tokens}
                 </div>
               </div>
-              <div className="bg-card rounded-md p-3 shadow-sm">
-                <div className="text-sm text-muted-foreground">
+              <div className="vkui:bg-card vkui:rounded-md vkui:p-3 vkui:shadow-sm">
+                <div className="vkui:text-sm vkui:text-muted-foreground">
                   Total Tokens
                 </div>
-                <div className="text-2xl font-medium">
+                <div className="vkui:text-2xl vkui:font-medium">
                   {tokenMetrics.total_tokens}
                 </div>
               </div>
@@ -211,15 +211,15 @@ export const Metrics: React.FC = () => {
         )}
         {hasMetrics && (
           <>
-            <h2 className="text-xl font-semibold">TTFB Metrics</h2>
-            <div className="grid grid-cols-1 @xl/metrics:grid-cols-2 @3xl/metrics:grid-cols-3 gap-4">
+            <h2 className="vkui:text-xl vkui:font-semibold">TTFB Metrics</h2>
+            <div className="vkui:grid vkui:grid-cols-1 vkui:@xl/metrics:grid-cols-2 vkui:@3xl/metrics:grid-cols-3 vkui:gap-4">
               {Object.entries(metrics).map(([processorName, data]) => (
                 <div
                   key={processorName}
-                  className="bg-card border rounded-lg shadow-sm p-3 h-60"
+                  className="vkui:bg-card vkui:border vkui:rounded-lg vkui:shadow-sm vkui:p-3 vkui:h-60"
                 >
-                  <h3 className="mb-2">{processorName}</h3>
-                  <div className="h-44">
+                  <h3 className="vkui:mb-2">{processorName}</h3>
+                  <div className="vkui:h-44">
                     <Line
                       data={generateChartData(processorName, data)}
                       options={chartOptions}
@@ -236,8 +236,8 @@ export const Metrics: React.FC = () => {
 
   if (isConnecting) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-muted-foreground text-sm">
+      <div className="vkui:flex vkui:items-center vkui:justify-center vkui:h-full">
+        <div className="vkui:text-muted-foreground vkui:text-sm">
           Connecting to agent...
         </div>
       </div>
@@ -246,12 +246,12 @@ export const Metrics: React.FC = () => {
 
   if (!isConnected) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="text-center p-4">
-          <div className="text-muted-foreground mb-2">
+      <div className="vkui:flex vkui:items-center vkui:justify-center vkui:h-full">
+        <div className="vkui:text-center vkui:p-4">
+          <div className="vkui:text-muted-foreground vkui:mb-2">
             Not connected to agent
           </div>
-          <p className="text-sm text-muted-foreground max-w-md">
+          <p className="vkui:text-sm vkui:text-muted-foreground vkui:max-w-md">
             Connect to an agent to view metrics in real-time.
           </p>
         </div>
@@ -260,8 +260,8 @@ export const Metrics: React.FC = () => {
   }
 
   return (
-    <div className="flex items-center justify-center h-full">
-      <div className="text-muted-foreground text-sm">
+    <div className="vkui:flex vkui:items-center vkui:justify-center vkui:h-full">
+      <div className="vkui:text-muted-foreground vkui:text-sm">
         Waiting for metrics data...
       </div>
     </div>

--- a/src/components/elements/SessionInfo.tsx
+++ b/src/components/elements/SessionInfo.tsx
@@ -22,17 +22,17 @@ export const SessionInfo: React.FC<{
 
   return (
     <DataList
-      className="w-full overflow-hidden"
+      className="vkui:w-full vkui:overflow-hidden"
       data={{
         Transport: transportTypeName,
         "Session ID": sessionId ? (
-          <CopyText className="justify-end" iconSize={12} text={sessionId} />
+          <CopyText className="vkui:justify-end" iconSize={12} text={sessionId} />
         ) : (
           "---"
         ),
         "Participant ID": participantId ? (
           <CopyText
-            className="justify-end"
+            className="vkui:justify-end"
             iconSize={12}
             text={participantId}
           />

--- a/src/components/elements/UserAudio.tsx
+++ b/src/components/elements/UserAudio.tsx
@@ -34,7 +34,7 @@ const UserAudio: React.FC = () => {
 
   if (!hasAudio) {
     return (
-      <div className="flex items-center gap-2 bg-muted rounded-md p-2 text-muted-foreground font-mono text-sm">
+      <div className="vkui:flex vkui:items-center vkui:gap-2 vkui:bg-muted vkui:rounded-md vkui:p-2 vkui:text-muted-foreground vkui:font-mono vkui:text-sm">
         <MicOffIcon size={16} />
         Audio disabled
       </div>
@@ -42,13 +42,13 @@ const UserAudio: React.FC = () => {
   }
 
   return (
-    <div className="flex flex-col gap-2">
-      <ButtonGroup className="w-full">
+    <div className="vkui:flex vkui:flex-col vkui:gap-2">
+      <ButtonGroup className="vkui:w-full">
         <RTVIClientMicToggle>
           {({ isMicEnabled, onClick }) => (
             <Button
               onClick={onClick}
-              className="flex-1 justify-start"
+              className="vkui:flex-1 vkui:justify-start"
               variant="secondary"
             >
               {isMicEnabled ? <MicIcon size={16} /> : <MicOffIcon size={16} />}
@@ -68,7 +68,7 @@ const UserAudio: React.FC = () => {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
-              className="border-s border-border p-2! flex-none"
+              className="vkui:border-s vkui:border-border vkui:p-2! vkui:flex-none"
               variant="secondary"
             >
               <ChevronDownIcon size={16} />

--- a/src/components/elements/UserVideo.tsx
+++ b/src/components/elements/UserVideo.tsx
@@ -21,25 +21,25 @@ export const UserVideo: React.FC = () => {
     <RTVIClientCamToggle>
       {({ isCamEnabled, onClick }) => (
         <div
-          className={cn("bg-muted rounded-xl relative", {
-            "aspect-video": isCamEnabled,
-            "h-12": !isCamEnabled,
+          className={cn("vkui:bg-muted vkui:rounded-xl vkui:relative", {
+            "vkui:aspect-video": isCamEnabled,
+            "vkui:h-12": !isCamEnabled,
           })}
         >
           <RTVIClientVideo
-            className={cn("rounded-xl", {
-              hidden: !isCamEnabled,
+            className={cn("vkui:rounded-xl", {
+              "vkui:hidden": !isCamEnabled,
             })}
             participant="local"
           />
           {!isCamEnabled && (
-            <div className="absolute h-full left-28 flex items-center justify-start rounded-xl">
-              <div className="text-muted-foreground font-mono text-sm">
+            <div className="vkui:absolute vkui:h-full vkui:left-28 vkui:flex vkui:items-center vkui:justify-start vkui:rounded-xl">
+              <div className="vkui:text-muted-foreground vkui:font-mono vkui:text-sm">
                 Camera is off
               </div>
             </div>
           )}
-          <div className="absolute bottom-2 left-2">
+          <div className="vkui:absolute vkui:bottom-2 vkui:left-2">
             <ButtonGroup>
               <Button variant="outline" onClick={onClick}>
                 {isCamEnabled ? <VideoIcon /> : <VideoOffIcon />}

--- a/src/components/panels/BotAudioPanel.tsx
+++ b/src/components/panels/BotAudioPanel.tsx
@@ -66,12 +66,12 @@ export const BotAudioPanel: React.FC<BotAudioPanelProps> = ({
           <PanelTitle>Bot Audio</PanelTitle>
         </PanelHeader>
       )}
-      <PanelContent className="overflow-hidden">
+      <PanelContent className="vkui:overflow-hidden">
         <div
           ref={containerRef}
-          className="relative aspect-video flex max-h-full overflow-hidden"
+          className="vkui:relative vkui:aspect-video vkui:flex vkui:max-h-full vkui:overflow-hidden"
         >
-          <div className="m-auto">
+          <div className="vkui:m-auto">
             <VoiceVisualizer
               participantType="bot"
               backgroundColor="transparent"
@@ -85,10 +85,10 @@ export const BotAudioPanel: React.FC<BotAudioPanelProps> = ({
             />
           </div>
           {!track && (
-            <div className="absolute inset-0 flex gap-1 items-center justify-center">
+            <div className="vkui:absolute vkui:inset-0 vkui:flex vkui:gap-1 vkui:items-center vkui:justify-center">
               <MicOffIcon size={16} />
               {!collapsed && (
-                <span className="font-mono text-xs">No audio</span>
+                <span className="vkui:font-mono vkui:text-xs">No audio</span>
               )}
             </div>
           )}

--- a/src/components/panels/BotVideoPanel.tsx
+++ b/src/components/panels/BotVideoPanel.tsx
@@ -24,7 +24,7 @@ export const BotVideoPanel: React.FC<BotVideoPanelProps> = ({
   return (
     <Panel
       className={cn(className, {
-        "border-none": collapsed,
+        "vkui:border-none": collapsed,
       })}
     >
       {!collapsed && (
@@ -33,19 +33,19 @@ export const BotVideoPanel: React.FC<BotVideoPanelProps> = ({
         </PanelHeader>
       )}
       <PanelContent
-        className={cn("relative overflow-hidden", {
-          "p-0!": collapsed,
+        className={cn("vkui:relative vkui:overflow-hidden", {
+          "vkui:p-0!": collapsed,
         })}
       >
         <RTVIClientVideo
           participant="bot"
-          className="aspect-video bg-muted rounded-sm max-h-full"
+          className="vkui:aspect-video vkui:bg-muted vkui:rounded-sm vkui:max-h-full"
           fit="contain"
         />
         {!track && (
-          <div className="absolute inset-0 flex gap-1 items-center justify-center">
+          <div className="vkui:absolute vkui:inset-0 vkui:flex vkui:gap-1 vkui:items-center vkui:justify-center">
             <VideoOffIcon size={16} />
-            {!collapsed && <span className="font-mono text-xs">No video</span>}
+            {!collapsed && <span className="vkui:font-mono vkui:text-xs">No video</span>}
           </div>
         )}
       </PanelContent>

--- a/src/components/panels/ConversationPanel.tsx
+++ b/src/components/panels/ConversationPanel.tsx
@@ -15,35 +15,35 @@ export const ConversationPanel: React.FC<Props> = ({
 }) => {
   const defaultValue = noConversation ? "metrics" : "conversation";
   return (
-    <Tabs className="h-full" defaultValue={defaultValue}>
-      <Panel className="h-full max-sm:border-none">
+    <Tabs className="vkui:h-full" defaultValue={defaultValue}>
+      <Panel className="vkui:h-full vkui:max-sm:border-none">
         <PanelHeader>
           <TabsList>
             {!noConversation && (
-              <TabsTrigger className="text-mono-upper" value="conversation">
+              <TabsTrigger className="vkui:text-mono-upper" value="conversation">
                 <MessagesSquareIcon size={16} />
                 Conversation
               </TabsTrigger>
             )}
             {!noMetrics && (
-              <TabsTrigger className="text-mono-upper" value="metrics">
+              <TabsTrigger className="vkui:text-mono-upper" value="metrics">
                 <LineChartIcon size={16} />
                 Metrics
               </TabsTrigger>
             )}
           </TabsList>
         </PanelHeader>
-        <PanelContent className="p-0! overflow-hidden h-full">
+        <PanelContent className="vkui:p-0! vkui:overflow-hidden vkui:h-full">
           {!noConversation && (
             <TabsContent
               value="conversation"
-              className="overflow-hidden h-full"
+              className="vkui:overflow-hidden vkui:h-full"
             >
               <Conversation />
             </TabsContent>
           )}
           {!noMetrics && (
-            <TabsContent value="metrics" className="h-full">
+            <TabsContent value="metrics" className="vkui:h-full">
               <Metrics />
             </TabsContent>
           )}

--- a/src/components/panels/EventsPanel.tsx
+++ b/src/components/panels/EventsPanel.tsx
@@ -225,27 +225,27 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
   return (
     <Panel
       className={cn(
-        "bg-secondary/20 h-full rounded-none! max-sm:border-none sm:mt-2",
+        "vkui:bg-secondary/20 vkui:h-full vkui:rounded-none! vkui:max-sm:border-none vkui:sm:border-x-0 vkui:sm:mt-2",
         {
-          "bg-secondary opacity-50": collapsed,
+          "vkui:bg-secondary vkui:opacity-50": collapsed,
         },
       )}
     >
       <PanelHeader
-        className={cn("gap-4 justify-start items-center", {
-          "py-2!": collapsed,
+        className={cn("vkui:gap-4 vkui:justify-start vkui:items-center", {
+          "vkui:py-2!": collapsed,
         })}
       >
         <PanelTitle>Events</PanelTitle>
         {!collapsed && (
-          <div className="relative">
-            <div className="absolute inset-y-0 left-0 flex items-center pl-2 pointer-events-none">
+          <div className="vkui:relative">
+            <div className="vkui:absolute vkui:inset-y-0 vkui:left-0 vkui:flex vkui:items-center vkui:pl-2 vkui:pointer-events-none">
               <FunnelIcon size={16} />
             </div>
             <Input
               type="text"
               placeholder="Filter"
-              className="bg-secondary max-w-48 ps-8"
+              className="vkui:bg-secondary vkui:max-w-48 vkui:ps-8"
               onChange={(e) => {
                 setFilter(e.target.value.toLowerCase());
               }}
@@ -254,14 +254,14 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
         )}
       </PanelHeader>
       {!collapsed && (
-        <PanelContent ref={scrollRef} className="overflow-y-auto">
-          <div className="grid grid-cols-[min-content_min-content_1fr] gap-x-4 gap-y-2 items-center font-mono text-xs">
+        <PanelContent ref={scrollRef} className="vkui:overflow-y-auto">
+          <div className="vkui:grid vkui:grid-cols-[min-content_min-content_1fr] vkui:gap-x-4 vkui:gap-y-2 vkui:items-center vkui:font-mono vkui:text-xs">
             {filteredEvents.map((eventData, index) => (
               <Fragment key={index}>
-                <div className="text-xs text-muted-foreground">
+                <div className="vkui:text-xs vkui:text-muted-foreground">
                   {eventData.time}
                 </div>
-                <div className="font-semibold">{eventData.event}</div>
+                <div className="vkui:font-semibold">{eventData.event}</div>
                 <div>{eventData.message}</div>
               </Fragment>
             ))}

--- a/src/components/panels/InfoPanel.tsx
+++ b/src/components/panels/InfoPanel.tsx
@@ -27,7 +27,7 @@ export const InfoPanel: React.FC<Props> = ({
 }) => {
   const noDevices = noAudioOutput && noUserAudio && noUserVideo;
   return (
-    <Panel className="h-full overflow-y-auto overflow-x-hidden">
+    <Panel className="vkui:h-full vkui:overflow-y-auto vkui:overflow-x-hidden">
       <PanelHeader variant="inline">
         <PanelTitle>Status</PanelTitle>
       </PanelHeader>
@@ -36,7 +36,7 @@ export const InfoPanel: React.FC<Props> = ({
       </PanelContent>
       {!noDevices && (
         <>
-          <PanelHeader className="border-t border-t-border" variant="inline">
+          <PanelHeader className="vkui:border-t vkui:border-t-border" variant="inline">
             <PanelTitle>Devices</PanelTitle>
           </PanelHeader>
           <PanelContent>
@@ -46,7 +46,7 @@ export const InfoPanel: React.FC<Props> = ({
           </PanelContent>
         </>
       )}
-      <PanelHeader className="border-t border-t-border" variant="inline">
+      <PanelHeader className="vkui:border-t vkui:border-t-border" variant="inline">
         <PanelTitle>Session</PanelTitle>
       </PanelHeader>
       <PanelContent>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,32 +6,32 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "vkui:inline-flex vkui:items-center vkui:justify-center vkui:gap-2 vkui:whitespace-nowrap vkui:rounded-lg vkui:text-sm vkui:font-medium vkui:transition-all vkui:disabled:pointer-events-none vkui:disabled:opacity-50 vkui:[&_svg]:pointer-events-none vkui:shrink-0 vkui:[&_svg]:shrink-0 vkui:outline-none vkui:focus-visible:border-ring vkui:focus-visible:ring-ring/50 vkui:focus-visible:ring-[3px] vkui:aria-invalid:ring-destructive/20 vkui:dark:aria-invalid:ring-destructive/40 vkui:aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "vkui:bg-primary vkui:text-primary-foreground vkui:hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "vkui:bg-destructive vkui:text-white vkui:hover:bg-destructive/90 vkui:focus-visible:ring-destructive/20 vkui:dark:focus-visible:ring-destructive/40 vkui:dark:bg-destructive/60",
         outline:
-          "text-foreground border bg-background hover:bg-accent dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "vkui:text-foreground vkui:border vkui:bg-background vkui:hover:bg-accent vkui:dark:bg-input/30 vkui:dark:border-input vkui:dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/60",
+          "vkui:bg-secondary vkui:text-secondary-foreground vkui:hover:bg-secondary/60",
         ghost:
-          "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-        muted: "bg-mute text-mute-foreground hover:text-mute",
+          "vkui:text-foreground vkui:hover:bg-accent vkui:hover:text-accent-foreground vkui:dark:hover:bg-accent/50",
+        link: "vkui:text-primary vkui:underline-offset-4 vkui:hover:underline",
+        muted: "vkui:bg-mute vkui:text-mute-foreground vkui:hover:text-mute",
       },
       size: {
         default:
-          "h-8 px-4 py-2 has-[>svg]:px-3 [&_svg:not([class*='size-'])]:size-5",
-        sm: "h-7 rounded-lg gap-1.5 px-3 has-[>svg]:px-2.5 [&_svg:not([class*='size-'])]:size-4",
-        lg: "h-10 rounded-lg px-6 has-[>svg]:px-4 [&_svg:not([class*='size-'])]:size-5",
-        icon: "h-8 w-8 p-0 has-[>svg]:p-0 [&_svg:not([class*='size-'])]:size-5",
+          "vkui:h-8 vkui:px-4 vkui:py-2 vkui:has-[>svg]:px-3 vkui:[&_svg:not([class*='size-'])]:size-5",
+        sm: "vkui:h-7 vkui:rounded-lg vkui:gap-1.5 vkui:px-3 vkui:has-[>svg]:px-2.5 vkui:[&_svg:not([class*='size-'])]:size-4",
+        lg: "vkui:h-10 vkui:rounded-lg vkui:px-6 vkui:has-[>svg]:px-4 vkui:[&_svg:not([class*='size-'])]:size-5",
+        icon: "vkui:h-8 vkui:w-8 vkui:p-0 vkui:has-[>svg]:p-0 vkui:[&_svg:not([class*='size-'])]:size-5",
         "icon-sm":
-          "h-7 w-7 p-0 has-[>svg]:p-0 [&_svg:not([class*='size-'])]:size-4",
+          "vkui:h-7 vkui:w-7 vkui:p-0 vkui:has-[>svg]:p-0 vkui:[&_svg:not([class*='size-'])]:size-4",
         "icon-xs":
-          "h-6 w-6 p-0 has-[>svg]:p-0 [&_svg:not([class*='size-'])]:size-3",
+          "vkui:h-6 vkui:w-6 vkui:p-0 vkui:has-[>svg]:p-0 vkui:[&_svg:not([class*='size-'])]:size-3",
       },
       isIcon: {
         true: "",
@@ -43,19 +43,19 @@ const buttonVariants = cva(
         size: "default",
         isIcon: true,
         className:
-          "size-8 @max-xs/panel:size-7 rounded-lg [&_svg:not([class*='size-'])]:size-5 @max-xs/panel:[&_svg:not([class*='size-'])]:size-4",
+          "vkui:size-8 vkui:@max-xs/panel:size-7 vkui:rounded-lg vkui:[&_svg:not([class*='size-'])]:size-5 vkui:@max-xs/panel:[&_svg:not([class*='size-'])]:size-4",
       },
       {
         size: "sm",
         isIcon: true,
         className:
-          "size-7 @max-xs/panel:size-6 rounded-lg [&_svg:not([class*='size-'])]:size-4 @max-xs/panel:[&_svg:not([class*='size-'])]:size-3",
+          "vkui:size-7 vkui:@max-xs/panel:size-6 vkui:rounded-lg vkui:[&_svg:not([class*='size-'])]:size-4 vkui:@max-xs/panel:[&_svg:not([class*='size-'])]:size-3",
       },
       {
         size: "lg",
         isIcon: true,
         className:
-          "size-10 @max-xs/panel:size-9 rounded-lg [&_svg:not([class*='size-'])]:size-5 @max-xs/panel:[&_svg:not([class*='size-'])]:size-4",
+          "vkui:size-10 vkui:@max-xs/panel:size-9 vkui:rounded-lg vkui:[&_svg:not([class*='size-'])]:size-5 vkui:@max-xs/panel:[&_svg:not([class*='size-'])]:size-4",
       },
     ],
     defaultVariants: {
@@ -89,7 +89,7 @@ function Button({
         {...props}
         disabled
       >
-        <LoaderIcon className="animate-spin" />
+        <LoaderIcon className="vkui:animate-spin" />
         {props.children}
       </Comp>
     );

--- a/src/components/ui/buttongroup.tsx
+++ b/src/components/ui/buttongroup.tsx
@@ -1,13 +1,13 @@
 import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
-const buttonGroupVariants = cva("flex items-center *:rounded-none", {
+const buttonGroupVariants = cva("vkui:flex vkui:items-center vkui:*:rounded-none", {
   variants: {
     orientation: {
       horizontal:
-        "flex-row *:first:rounded-s-md *:last:rounded-e-md *:-ml-[1px] *:first:ml-0",
+        "vkui:flex-row vkui:*:first:rounded-s-md vkui:*:last:rounded-e-md vkui:*:-ml-[1px] vkui:*:first:ml-0",
       vertical:
-        "flex-col *:first:rounded-t-md *:last:rounded-b-md *:-mt-[1px] *:first:mt-0",
+        "vkui:flex-col vkui:*:first:rounded-t-md vkui:*:last:rounded-b-md vkui:*:-mt-[1px] vkui:*:first:mt-0",
     },
   },
   defaultVariants: {
@@ -23,7 +23,7 @@ export const ButtonGroup = ({
 }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) => {
   return (
     <div
-      className={cn("flex", buttonGroupVariants({ orientation }), className)}
+      className={cn("vkui:flex", buttonGroupVariants({ orientation }), className)}
       {...props}
     >
       {children}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-2 md:gap-3 rounded-2xl border p-2 md:p-3",
+        "bg-card text-card-foreground vkui:flex vkui:flex-col vkui:gap-2 vkui:md:gap-3 vkui:rounded-2xl vkui:border vkui:p-2 vkui:md:p-3",
         className,
       )}
       {...props}
@@ -19,7 +19,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
-      className={cn("flex gap-2 md:gap-3 p-2 md:p-3", className)}
+      className={cn("vkui:flex vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3", className)}
       {...props}
     />
   );
@@ -29,7 +29,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("vkui:leading-none vkui:font-semibold", className)}
       {...props}
     />
   );
@@ -39,7 +39,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("vkui:text-muted-foreground vkui:text-sm", className)}
       {...props}
     />
   );
@@ -50,7 +50,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-action"
       className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        "vkui:col-start-2 vkui:row-span-2 vkui:row-start-1 vkui:self-start vkui:justify-self-end",
         className,
       )}
       {...props}
@@ -62,7 +62,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("gap-2 md:gap-3 p-2 md:p-3", className)}
+      className={cn("vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3", className)}
       {...props}
     />
   );
@@ -72,7 +72,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex gap-2 md:gap-3 p-2 md:p-3", className)}
+      className={cn("vkui:flex vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3", className)}
       {...props}
     />
   );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "vkui:bg-popover vkui:text-popover-foreground vkui:data-[state=open]:animate-in vkui:data-[state=closed]:animate-out vkui:data-[state=closed]:fade-out-0 vkui:data-[state=open]:fade-in-0 vkui:data-[state=closed]:zoom-out-95 vkui:data-[state=open]:zoom-in-95 vkui:data-[side=bottom]:slide-in-from-top-2 vkui:data-[side=left]:slide-in-from-right-2 vkui:data-[side=right]:slide-in-from-left-2 vkui:data-[side=top]:slide-in-from-bottom-2 vkui:z-50 vkui:max-h-(--radix-dropdown-menu-content-available-height) vkui:min-w-[8rem] vkui:origin-(--radix-dropdown-menu-content-transform-origin) vkui:overflow-x-hidden vkui:overflow-y-auto vkui:rounded-md vkui:border vkui:p-1 vkui:shadow-md",
           className,
         )}
         {...props}
@@ -77,7 +77,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "vkui:focus:bg-accent vkui:focus:text-accent-foreground vkui:data-[variant=destructive]:text-destructive vkui:data-[variant=destructive]:focus:bg-destructive/10 vkui:dark:data-[variant=destructive]:focus:bg-destructive/20 vkui:data-[variant=destructive]:focus:text-destructive vkui:data-[variant=destructive]:*:[svg]:!text-destructive vkui:[&_svg:not([class*='text-'])]:text-muted-foreground vkui:relative vkui:flex vkui:cursor-default vkui:items-center vkui:gap-2 vkui:rounded-sm vkui:px-2 vkui:py-1.5 vkui:text-sm vkui:outline-hidden vkui:select-none vkui:data-[disabled]:pointer-events-none vkui:data-[disabled]:opacity-50 vkui:data-[inset]:pl-8 vkui:[&_svg]:pointer-events-none vkui:[&_svg]:shrink-0 vkui:[&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -95,13 +95,13 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "vkui:focus:bg-accent vkui:focus:text-accent-foreground vkui:relative vkui:flex vkui:cursor-default vkui:items-center vkui:gap-2 vkui:rounded-sm vkui:py-1.5 vkui:pr-2 vkui:pl-8 vkui:text-sm vkui:outline-hidden vkui:select-none vkui:data-[disabled]:pointer-events-none vkui:data-[disabled]:opacity-50 vkui:[&_svg]:pointer-events-none vkui:[&_svg]:shrink-0 vkui:[&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="vkui:pointer-events-none vkui:absolute vkui:left-2 vkui:flex size-3.5 vkui:items-center vkui:justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
@@ -131,14 +131,14 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "vkui:focus:bg-accent vkui:focus:text-accent-foreground vkui:relative vkui:flex vkui:cursor-default vkui:items-center vkui:gap-2 vkui:rounded-sm vkui:py-1.5 vkui:pr-2 vkui:pl-8 vkui:text-sm vkui:outline-hidden vkui:select-none vkui:data-[disabled]:pointer-events-none vkui:data-[disabled]:opacity-50 vkui:[&_svg]:pointer-events-none vkui:[&_svg]:shrink-0 vkui:[&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="vkui:pointer-events-none vkui:absolute vkui:left-2 vkui:flex vkui:size-3.5 vkui:items-center vkui:justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <CircleIcon className="size-2 vkui:fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -158,7 +158,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        "vkui:px-2 vkui:py-1.5 vkui:text-sm vkui:font-medium vkui:data-[inset]:pl-8",
         className,
       )}
       {...props}
@@ -173,7 +173,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn("vkui:bg-border vkui:-mx-1 vkui:my-1 vkui:h-px", className)}
       {...props}
     />
   );
@@ -187,7 +187,7 @@ function DropdownMenuShortcut({
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
+        "vkui:text-muted-foreground vkui:ml-auto vkui:text-xs vkui:tracking-widest",
         className,
       )}
       {...props}
@@ -214,13 +214,13 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "vkui:focus:bg-accent vkui:focus:text-accent-foreground vkui:data-[state=open]:bg-accent vkui:data-[state=open]:text-accent-foreground vkui:flex vkui:cursor-default vkui:items-center vkui:rounded-sm vkui:px-2 vkui:py-1.5 vkui:text-sm vkui:outline-hidden vkui:select-none vkui:data-[inset]:pl-8",
         className,
       )}
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      <ChevronRightIcon className="vkui:ml-auto vkui:size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   );
 }
@@ -233,7 +233,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "vkui:bg-popover vkui:text-popover-foreground vkui:data-[state=open]:animate-in vkui:data-[state=closed]:animate-out vkui:data-[state=closed]:fade-out-0 vkui:data-[state=open]:fade-in-0 vkui:data-[state=closed]:zoom-out-95 vkui:data-[state=open]:zoom-in-95 vkui:data-[side=bottom]:slide-in-from-top-2 vkui:data-[side=left]:slide-in-from-right-2 vkui:data-[side=right]:slide-in-from-left-2 vkui:data-[side=top]:slide-in-from-bottom-2 vkui:z-50 vkui:min-w-[8rem] vkui:origin-(--radix-dropdown-menu-content-transform-origin) vkui:overflow-hidden vkui:rounded-md vkui:border vkui:p-1 vkui:shadow-lg",
         className,
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,13 +4,13 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const inputVariants = cva(
-  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full min-w-0 rounded-md border bg-transparent px-3 text-foreground transition-[color,box-shadow] outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "vkui:file:text-foreground vkui:placeholder:text-muted-foreground vkui:selection:bg-primary vkui:selection:text-primary-foreground vkui:dark:bg-input/30 vkui:border-input vkui:flex vkui:w-full vkui:min-w-0 vkui:rounded-md vkui:border vkui:bg-transparent vkui:px-3 vkui:text-foreground vkui:transition-[color,box-shadow] vkui:outline-none vkui:file:inline-flex vkui:file:border-0 vkui:file:bg-transparent vkui:file:text-sm vkui:file:font-medium vkui:disabled:pointer-events-none vkui:disabled:cursor-not-allowed vkui:disabled:opacity-50 vkui:md:text-sm vkui:focus-visible:border-ring vkui:focus-visible:ring-ring/50 vkui:focus-visible:ring-[3px] vkui:aria-invalid:ring-destructive/20 vkui:dark:aria-invalid:ring-destructive/40 vkui:aria-invalid:border-destructive",
   {
     variants: {
       size: {
-        sm: "h-7 px-2.5 py-1 text-sm",
-        default: "h-8 px-3 py-1",
-        lg: "h-10 px-3 py-2 rounded-lg",
+        sm: "vkui:h-7 vkui:px-2.5 vkui:py-1 vkui:text-sm",
+        default: "vkui:h-8 vkui:px-3 vkui:py-1",
+        lg: "vkui:h-10 vkui:px-3 vkui:py-2 vkui:rounded-lg",
       },
     },
     defaultVariants: {

--- a/src/components/ui/panel.tsx
+++ b/src/components/ui/panel.tsx
@@ -8,7 +8,7 @@ function Panel({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="panel"
       className={cn(
-        "@container/panel bg-card text-card-foreground flex flex-col rounded-panel border",
+        "vkui:@container/panel vkui:bg-card vkui:text-card-foreground vkui:flex vkui:flex-col vkui:rounded-panel vkui:border",
         className,
       )}
       {...props}
@@ -16,12 +16,12 @@ function Panel({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-const PanelHeaderVariants = cva("@container/panel-header", {
+const PanelHeaderVariants = cva("vkui:@container/panel-header", {
   variants: {
     variant: {
       default:
-        "border-b flex items-center justify-center h-panel-header text-card-foreground p-2 @xs/panel:p-3 @md/panel:p-4",
-      inline: "items-start text-foreground p-2 @xs/panel:p-3 @md/panel:p-4",
+        "vkui:border-b vkui:flex vkui:items-center vkui:justify-center vkui:text-card-foreground vkui:p-2 vkui:@xs/panel:p-3 vkui:@md/panel:p-4",
+      inline: "vkui:items-start vkui:text-foreground vkui:p-2 vkui:@xs/panel:p-3 vkui:@md/panel:p-4",
     },
   },
   defaultVariants: {
@@ -47,7 +47,7 @@ function PanelTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="panel-title"
-      className={cn("text-mono-upper", className)}
+      className={cn("vkui:text-mono-upper", className)}
       {...props}
     />
   );
@@ -58,7 +58,7 @@ function PanelContent({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="panel-content"
       className={cn(
-        "text-foreground flex flex-col p-2 gap-2 @xs/panel:p-3 @xs/panel:gap-3 @md/panel:p-4 @md/panel:gap-4",
+        "vkui:text-foreground vkui:flex vkui:flex-col vkui:p-2 vkui:gap-2 vkui:@xs/panel:p-3 vkui:@xs/panel:gap-3 vkui:@md/panel:p-4 vkui:@md/panel:gap-4",
         className,
       )}
       {...props}
@@ -71,7 +71,7 @@ function PanelFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="panel-footer"
       className={cn(
-        "flex items-center p-2 @xs/panel:p-3 @md/panel:p-4",
+        "vkui:flex vkui:items-center vkui:p-2 vkui:@xs/panel:p-3 vkui:@md/panel:p-4",
         className,
       )}
       {...props}
@@ -83,7 +83,7 @@ function PanelActions({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="panel-actions"
-      className={cn("flex items-center gap-1 @xs/panel:gap-2", className)}
+      className={cn("vkui:flex vkui:items-center vkui:gap-1 vkui:@xs/panel:gap-2", className)}
       {...props}
     />
   );

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -29,7 +29,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "vkui:bg-popover vkui:text-popover-foreground vkui:data-[state=open]:animate-in vkui:data-[state=closed]:animate-out vkui:data-[state=closed]:fade-out-0 vkui:data-[state=open]:fade-in-0 vkui:data-[state=closed]:zoom-out-95 vkui:data-[state=open]:zoom-in-95 vkui:data-[side=bottom]:slide-in-from-top-2 vkui:data-[side=left]:slide-in-from-right-2 vkui:data-[side=right]:slide-in-from-left-2 vkui:data-[side=top]:slide-in-from-bottom-2 vkui:z-50 vkui:w-72 origin-(--radix-popover-content-transform-origin) vkui:rounded-md vkui:border vkui:p-4 vkui:shadow-md vkui:outline-hidden",
           className,
         )}
         {...props}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -12,7 +12,7 @@ function ResizablePanelGroup({
     <ResizablePrimitive.PanelGroup
       data-slot="resizable-panel-group"
       className={cn(
-        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+        "vkui:flex vkui:h-full vkui:w-full vkui:data-[panel-group-direction=vertical]:flex-col",
         className,
       )}
       {...props}
@@ -37,7 +37,7 @@ function ResizableHandle({
     <ResizablePrimitive.PanelResizeHandle
       data-slot="resizable-handle"
       className={cn(
-        "focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "vkui:focus-visible:ring-ring vkui:relative vkui:flex vkui:w-px vkui:items-center vkui:justify-center vkui:after:absolute vkui:after:inset-y-0 vkui:after:left-1/2 vkui:after:w-1 vkui:after:-translate-x-1/2 vkui:focus-visible:ring-1 vkui:focus-visible:ring-offset-1 focus-visible:outline-hidden vkui:data-[panel-group-direction=vertical]:h-px vkui:data-[panel-group-direction=vertical]:w-full vkui:data-[panel-group-direction=vertical]:after:left-0 vkui:data-[panel-group-direction=vertical]:after:h-1 vkui:data-[panel-group-direction=vertical]:after:w-full vkui:data-[panel-group-direction=vertical]:after:-translate-y-1/2 vkui:data-[panel-group-direction=vertical]:after:translate-x-0 vkui:[&[data-panel-group-direction=vertical]>div]:rotate-90",
         className,
       )}
       {...props}
@@ -45,9 +45,9 @@ function ResizableHandle({
       {withHandle && (
         <div
           className={cn(
-            "border-transparent z-10 flex h-8 w-4 items-center justify-center rounded-xs border",
+            "vkui:border-transparent vkui:z-10 vkui:flex vkui:h-8 vkui:w-4 vkui:items-center vkui:justify-center vkui:rounded-xs vkui:border",
             {
-              "h-4 w-8": props["aria-orientation"] === "horizontal",
+              "vkui:h-4 vkui:w-8": props["aria-orientation"] === "horizontal",
             },
           )}
         >

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -12,13 +12,13 @@ import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const selectTriggerVariants = cva(
-  "border-input text-foreground data-[placeholder]:text-muted-foreground font-mono text-xs [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between rounded-lg border bg-transparent whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "vkui:border-input vkui:text-foreground vkui:data-[placeholder]:text-muted-foreground vkui:font-mono vkui:text-xs vkui:[&_svg:not([class*='text-'])]:text-muted-foreground vkui:focus-visible:border-ring vkui:focus-visible:ring-ring/50 vkui:aria-invalid:ring-destructive/20 vkui:dark:aria-invalid:ring-destructive/40 vkui:aria-invalid:border-destructive vkui:dark:bg-input/30 vkui:dark:hover:bg-input/50 vkui:flex w-fit vkui:items-center vkui:justify-between vkui:rounded-lg vkui:border vkui:bg-transparent vkui:whitespace-nowrap vkui:transition-[color,box-shadow] vkui:outline-none vkui:focus-visible:ring-[3px] vkui:disabled:cursor-not-allowed vkui:disabled:opacity-50 vkui:*:data-[slot=select-value]:line-clamp-1 vkui:*:data-[slot=select-value]:flex vkui:*:data-[slot=select-value]:items-center vkui:*:data-[slot=select-value]:gap-2 vkui:[&_svg]:pointer-events-none vkui:[&_svg]:shrink-0",
   {
     variants: {
       size: {
-        default: "h-8 pl-3 pr-2.5 py-2 gap-2 [&_svg]:size-3.5",
-        sm: "h-7 pl-3 pr-2.5 py-1.5 gap-2 [&_svg]:size-3.5",
-        lg: "h-10 px-3.5 py-2.5 gap-3 [&_svg]:size-4",
+        default: "vkui:h-8 vkui:pl-3 vkui:pr-2.5 vkui:py-2 vkui:gap-2 vkui:[&_svg]:size-3.5",
+        sm: "vkui:h-7 vkui:pl-3 vkui:pr-2.5 vkui:py-1.5 vkui:gap-2 vkui:[&_svg]:size-3.5",
+        lg: "vkui:h-10 vkui:px-3.5 vkui:py-2.5 vkui:gap-3 vkui:[&_svg]:size-4",
       },
     },
     defaultVariants: {
@@ -56,12 +56,12 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
-      className={cn(selectTriggerVariants({ size }), "truncate", className)}
+      className={cn(selectTriggerVariants({ size }), "vkui:truncate", className)}
       {...props}
     >
-      <span className="truncate flex-1 min-w-0">{children}</span>
+      <span className="vkui:truncate vkui:flex-1 vkui:min-w-0">{children}</span>
       <SelectPrimitive.Icon asChild>
-        <SelectChevronIcon className="opacity-50 flex-none" />
+        <SelectChevronIcon className="vkui:opacity-50 vkui:flex-none" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -71,7 +71,7 @@ function SelectGuide({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="select-guide"
-      className={cn("text-subtle font-sans", className)}
+      className={cn("vkui:text-subtle vkui:font-sans", className)}
       {...props}
     />
   );
@@ -88,9 +88,9 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "vkui:bg-popover vkui:text-popover-foreground vkui:data-[state=open]:animate-in vkui:data-[state=closed]:animate-out vkui:data-[state=closed]:fade-out-0 vkui:data-[state=open]:fade-in-0 vkui:data-[state=closed]:zoom-out-95 vkui:data-[state=open]:zoom-in-95 vkui:data-[side=bottom]:slide-in-from-top-2 vkui:data-[side=left]:slide-in-from-right-2 vkui:data-[side=right]:slide-in-from-left-2 vkui:data-[side=top]:slide-in-from-bottom-2 vkui:relative vkui:z-50 vkui:max-h-(--radix-select-content-available-height) vkui:min-w-[8rem] vkui:origin-(--radix-select-content-transform-origin) vkui:overflow-x-hidden vkui:overflow-y-auto vkui:rounded-md vkui:border vkui:shadow-md",
           position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+            "vkui:data-[side=bottom]:translate-y-1 vkui:data-[side=left]:-translate-x-1 vkui:data-[side=right]:translate-x-1 vkui:data-[side=top]:-translate-y-1",
           className,
         )}
         position={position}
@@ -99,9 +99,9 @@ function SelectContent({
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
-            "p-1",
+            "vkui:p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+              "vkui:h-[var(--radix-select-trigger-height)] vkui:w-full vkui:min-w-[var(--radix-select-trigger-width)] vkui:scroll-my-1",
           )}
         >
           {children}
@@ -121,12 +121,12 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "vkui:focus:bg-accent vkui:focus:text-accent-foreground vkui:[&_svg:not([class*='text-'])]:text-muted-foreground vkui:relative vkui:flex vkui:w-full vkui:cursor-default vkui:items-center vkui:gap-2 vkui:rounded-sm vkui:py-1.5 vkui:pr-8 vkui:pl-2 vkui:text-sm vkui:outline-hidden vkui:select-none vkui:data-[disabled]:pointer-events-none vkui:data-[disabled]:opacity-50 [&_svg]:pointer-events-none vkui:[&_svg]:shrink-0 vkui:[&_svg:not([class*='size-'])]:size-4 vkui:*:[span]:last:flex vkui:*:[span]:last:items-center vkui:*:[span]:last:gap-2",
         className,
       )}
       {...props}
     >
-      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+      <span className="vkui:absolute vkui:right-2 vkui:flex vkui:size-3.5 vkui:items-center vkui:justify-center">
         <SelectPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>
@@ -143,7 +143,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      className={cn("vkui:bg-border vkui:pointer-events-none vkui:-mx-1 vkui:my-1 vkui:h-px", className)}
       {...props}
     />
   );
@@ -157,7 +157,7 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "vkui:flex vkui:cursor-default vkui:items-center vkui:justify-center vkui:py-1",
         className,
       )}
       {...props}
@@ -175,7 +175,7 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "vkui:flex vkui:cursor-default vkui:items-center vkui:justify-center vkui:py-1",
         className,
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -10,7 +10,7 @@ function Tabs({
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn("vkui:flex vkui:flex-col vkui:gap-2", className)}
       {...props}
     />
   );
@@ -24,7 +24,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "vkui:bg-muted vkui:text-muted-foreground vkui:inline-flex vkui:h-9 vkui:w-fit vkui:items-center vkui:justify-center vkui:rounded-lg p-[3px]",
         className,
       )}
       {...props}
@@ -40,7 +40,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring hover:bg-muted-foreground/10 dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "vkui:data-[state=active]:bg-background vkui:data-[state=active]:text-foreground vkui:focus-visible:border-ring vkui:focus-visible:ring-ring/50 vkui:focus-visible:outline-ring vkui:hover:bg-muted-foreground/10 vkui:dark:data-[state=active]:border-input vkui:dark:data-[state=active]:bg-input/30 vkui:text-foreground vkui:inline-flex vkui:h-[calc(100%-1px)] vkui:flex-1 vkui:items-center vkui:justify-center vkui:gap-1.5 vkui:rounded-md vkui:border vkui:border-transparent vkui:px-2 vkui:py-1 vkui:text-sm vkui:font-medium vkui:whitespace-nowrap vkui:transition-[color,box-shadow] vkui:focus-visible:ring-[3px] vkui:focus-visible:outline-1 vkui:disabled:pointer-events-none vkui:disabled:opacity-50 vkui:data-[state=active]:shadow-sm vkui:[&_svg]:pointer-events-none vkui:[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -57,7 +57,7 @@ function TabsContent({
       data-slot="tabs-content"
       forceMount
       className={cn(
-        "flex-1 outline-none data-[state=inactive]:hidden",
+        "vkui:flex-1 vkui:outline-none vkui:data-[state=inactive]:hidden",
         className,
       )}
       {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -45,13 +45,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "vkui:bg-primary vkui:text-primary-foreground vkui:animate-in vkui:fade-in-0 vkui:zoom-in-95 vkui:data-[state=closed]:animate-out vkui:data-[state=closed]:fade-out-0 vkui:data-[state=closed]:zoom-out-95 vkui:data-[side=bottom]:slide-in-from-top-2 vkui:data-[side=left]:slide-in-from-right-2 vkui:data-[side=right]:slide-in-from-left-2 vkui:data-[side=top]:slide-in-from-bottom-2 vkui:z-50 vkui:w-fit vkui:origin-(--radix-tooltip-content-transform-origin) vkui:rounded-md vkui:px-3 vkui:py-1.5 vkui:text-xs vkui:text-balance",
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="vkui:bg-primary vkui:fill-primary vkui:z-50 vkui:size-2.5 vkui:translate-y-[calc(-50%_-_2px)] vkui:rotate-45 vkui:rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
-@import "tailwindcss";
+@import "tailwindcss" prefix(vkui);
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.vkui\:dark *));
 
 @theme static {
   --font-sans: "Geist", "Inter", -apple-system, "Segoe UI", Roboto, sans-serif;
@@ -13,7 +13,7 @@
     0px 7px 3px rgba(0, 0, 0, 0.01), 0px 4px 2px rgba(0, 0, 0, 0.03),
     0px 2px 2px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.05);
 
-  --radius-panel: var(--radius-sm);
+  --radius-panel: var(--vkui-radius-sm);
 
   --color-background: oklch(1 0 0);
   --color-foreground: oklch(0.141 0.005 285.823);
@@ -44,54 +44,57 @@
   --color-chart-5: oklch(0.769 0.188 70.08);
 }
 
-:root {
-  --height-panel-header: 40px;
-}
+.vkui\:dark {
+  --vkui-color-background: oklch(0.141 0.005 285.823);
+  --vkui-color-foreground: oklch(0.985 0 0);
+  --vkui-color-card: oklch(0.21 0.006 285.885);
+  --vkui-color-card-foreground: oklch(0.985 0 0);
+  --vkui-color-popover: oklch(0.21 0.006 285.885);
+  --vkui-color-popover-foreground: oklch(0.985 0 0);
+  --vkui-color-primary: oklch(0.92 0.004 286.32);
+  --vkui-color-primary-foreground: oklch(0.21 0.006 285.885);
+  --vkui-color-secondary: oklch(0.274 0.006 286.033);
+  --vkui-color-secondary-foreground: oklch(0.985 0 0);
+  --vkui-color-muted: oklch(0.274 0.006 286.033);
+  --vkui-color-muted-foreground: oklch(0.705 0.015 286.067);
+  --vkui-color-accent: oklch(0.274 0.006 286.033);
+  --vkui-color-accent-foreground: oklch(0.985 0 0);
+  --vkui-color-destructive: oklch(57.7% 0.245 27.325);
+  --vkui-color-border: oklch(1 0 0 / 10%);
+  --vkui-color-input: oklch(1 0 0 / 15%);
+  --vkui-color-ring: oklch(0.552 0.016 285.938);
+  --vkui-color-subtle: oklch(44.2% 0.017 285.786);
+  --vkui-color-mute: oklch(57.7% 0.245 27.325);
+  --vkui-color-mute-foreground: oklch(97% 0.05 27.325);
 
-.dark {
-  --color-background: oklch(0.141 0.005 285.823);
-  --color-foreground: oklch(0.985 0 0);
-  --color-card: oklch(0.21 0.006 285.885);
-  --color-card-foreground: oklch(0.985 0 0);
-  --color-popover: oklch(0.21 0.006 285.885);
-  --color-popover-foreground: oklch(0.985 0 0);
-  --color-primary: oklch(0.92 0.004 286.32);
-  --color-primary-foreground: oklch(0.21 0.006 285.885);
-  --color-secondary: oklch(0.274 0.006 286.033);
-  --color-secondary-foreground: oklch(0.985 0 0);
-  --color-muted: oklch(0.274 0.006 286.033);
-  --color-muted-foreground: oklch(0.705 0.015 286.067);
-  --color-accent: oklch(0.274 0.006 286.033);
-  --color-accent-foreground: oklch(0.985 0 0);
-  --color-destructive: oklch(57.7% 0.245 27.325);
-  --color-border: oklch(1 0 0 / 10%);
-  --color-input: oklch(1 0 0 / 15%);
-  --color-ring: oklch(0.552 0.016 285.938);
-  --color-subtle: oklch(44.2% 0.017 285.786);
-  --color-mute: oklch(57.7% 0.245 27.325);
-  --color-mute-foreground: oklch(97% 0.05 27.325);
-
-  --color-chart-1: oklch(0.488 0.243 264.376);
-  --color-chart-2: oklch(0.696 0.17 162.48);
-  --color-chart-3: oklch(0.769 0.188 70.08);
-  --color-chart-4: oklch(0.627 0.265 303.9);
-  --color-chart-5: oklch(0.645 0.246 16.439);
+  --vkui-color-chart-1: oklch(0.488 0.243 264.376);
+  --vkui-color-chart-2: oklch(0.696 0.17 162.48);
+  --vkui-color-chart-3: oklch(0.769 0.188 70.08);
+  --vkui-color-chart-4: oklch(0.627 0.265 303.9);
+  --vkui-color-chart-5: oklch(0.645 0.246 16.439);
 }
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--vkui-color-border);
+    outline-color: color-mix(in oklab, var(--vkui-color-ring));
   }
 
   :root {
-    @apply text-foreground font-sans;
+    color: var(--vkui-color-foreground);
+    font-family: var(--vkui-font-sans);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
 }
 
 @layer components {
-  .text-mono-upper {
-    @apply font-mono font-bold text-xs uppercase tracking-wider leading-none;
+  .vkui\:text-mono-upper {
+    font-family: var(--vkui-font-mono);
+    font-weight: var(--vkui-font-weight-bold);
+    font-size: var(--vkui-text-xs);
+    line-height: var(--tw-leading, var(--vkui-text-xs--line-height));
+    letter-spacing: var(--vkui-tracking-wider);
+    line-height: 1;
   }
 }

--- a/src/templates/Console/index.tsx
+++ b/src/templates/Console/index.tsx
@@ -265,18 +265,18 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
 
   return (
     <RTVIClientProvider client={rtviClient}>
-      <div className="grid grid-cols-1 grid-rows-[min-content_1fr] sm:grid-rows-[min-content_1fr_auto] h-full w-full overflow-auto">
-        <div className="grid grid-cols-2 sm:grid-cols-[150px_1fr_150px] gap-2 items-center justify-center p-2 bg-background sm:relative top-0 w-full z-10">
+      <div className="vkui:grid vkui:grid-cols-1 vkui:grid-rows-[min-content_1fr] vkui:sm:grid-rows-[min-content_1fr_auto] vkui:h-full vkui:w-full vkui:overflow-auto">
+        <div className="vkui:grid vkui:grid-cols-2 vkui:sm:grid-cols-[150px_1fr_150px] vkui:gap-2 vkui:items-center vkui:justify-center vkui:p-2 vkui:bg-background vkui:sm:relative vkui:top-0 vkui:w-full vkui:z-10">
           {noLogo ? (
-            <span className="h-6" />
+            <span className="vkui:h-6" />
           ) : (
             <PipecatLogo
-              className="h-6 w-auto"
+              className="vkui:h-6 vkui:w-auto"
               color={resolvedTheme === "dark" ? "#ffffff" : "#171717"}
             />
           )}
-          <strong className="hidden sm:block text-center">{title}</strong>
-          <div className="flex items-center justify-end gap-4">
+          <strong className="vkui:hidden vkui:sm:block vkui:text-center">{title}</strong>
+          <div className="vkui:flex vkui:items-center vkui:justify-end vkui:gap-4">
             {!noThemeSwitch && <ThemeModeToggle />}
             <ConnectButton
               onConnect={handleConnect}
@@ -284,14 +284,14 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
             />
           </div>
         </div>
-        <div className="hidden sm:block">
-          <ResizablePanelGroup direction="vertical" className="h-full">
+        <div className="vkui:hidden vkui:sm:block">
+          <ResizablePanelGroup direction="vertical" className="vkui:h-full">
             <ResizablePanel defaultSize={70} minSize={50}>
               <ResizablePanelGroup direction="horizontal">
                 {!noBotArea && (
                   <>
                     <ResizablePanel
-                      className="flex flex-col gap-2 p-2"
+                      className="vkui:flex vkui:flex-col vkui:gap-2 vkui:p-2"
                       defaultSize={15}
                       maxSize={30}
                       minSize={9}
@@ -303,7 +303,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                       {!noBotAudio && (
                         <BotAudioPanel
                           className={cn({
-                            "max-h-[calc(50%-4px)] mt-auto": !noBotVideo,
+                            "vkui:max-h-[calc(50%-4px)] vkui:mt-auto": !noBotVideo,
                           })}
                           collapsed={isBotAreaCollapsed}
                         />
@@ -311,7 +311,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                       {!noBotVideo && (
                         <BotVideoPanel
                           className={cn({
-                            "max-h-[calc(50%-4px)] mb-auto": !noBotAudio,
+                            "vkui:max-h-[calc(50%-4px)] vkui:mb-auto": !noBotAudio,
                           })}
                           collapsed={isBotAreaCollapsed}
                         />
@@ -323,7 +323,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                 {!noConversationPanel && (
                   <>
                     <ResizablePanel
-                      className="h-full p-2"
+                      className="vkui:h-full vkui:p-2"
                       defaultSize={60}
                       minSize={40}
                     >
@@ -343,10 +343,10 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                   defaultSize={20}
                   onCollapse={() => setIsInfoPanelCollapsed(true)}
                   onExpand={() => setIsInfoPanelCollapsed(false)}
-                  className="p-2"
+                  className="vkui:p-2"
                 >
                   {isInfoPanelCollapsed ? (
-                    <div className="flex flex-col items-center justify-center gap-4 h-full">
+                    <div className="vkui:flex vkui:flex-col vkui:items-center vkui:justify-center vkui:gap-4 vkui:h-full">
                       <Popover>
                         <PopoverTrigger asChild>
                           <Button variant="ghost" size="icon">
@@ -365,7 +365,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                             </Button>
                           </PopoverTrigger>
                           <PopoverContent
-                            className="flex flex-col gap-2"
+                            className="vkui:flex vkui:flex-col vkui:gap-2"
                             side="left"
                           >
                             {!noUserAudio && <UserAudio />}
@@ -416,13 +416,13 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
           defaultValue={
             noBotArea ? (noConversationPanel ? "info" : "conversation") : "bot"
           }
-          className="flex flex-col gap-0 sm:hidden overflow-hidden"
+          className="vkui:flex vkui:flex-col vkui:gap-0 vkui:sm:hidden vkui:overflow-hidden"
         >
-          <div className="flex flex-col overflow-hidden">
+          <div className="vkui:flex vkui:flex-col vkui:overflow-hidden">
             {!noBotArea && (
               <TabsContent
                 value="bot"
-                className="flex-1 overflow-auto flex flex-col gap-4 p-2"
+                className="vkui:flex-1 vkui:overflow-auto vkui:flex vkui:flex-col vkui:gap-4 vkui:p-2"
               >
                 {!noBotAudio && <BotAudioPanel />}
                 {!noBotVideo && <BotVideoPanel />}
@@ -431,7 +431,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
             {!noConversationPanel && (
               <TabsContent
                 value="conversation"
-                className="flex-1 overflow-auto"
+                className="vkui:flex-1 vkui:overflow-auto"
               >
                 <ConversationPanel
                   noConversation={noConversation}
@@ -439,7 +439,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                 />
               </TabsContent>
             )}
-            <TabsContent value="info" className="flex-1 overflow-auto p-2">
+            <TabsContent value="info" className="vkui:flex-1 vkui:overflow-auto vkui:p-2">
               <InfoPanel
                 noAudioOutput={noAudioOutput}
                 noUserAudio={noUserAudio}
@@ -448,11 +448,11 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                 sessionId={sessionId}
               />
             </TabsContent>
-            <TabsContent value="events" className="flex-1 overflow-auto">
+            <TabsContent value="events" className="vkui:flex-1 vkui:overflow-auto">
               <EventsPanel />
             </TabsContent>
           </div>
-          <TabsList className="w-full h-12 rounded-none z-10 mt-auto shrink-0">
+          <TabsList className="vkui:w-full vkui:h-12 vkui:rounded-none vkui:z-10 vkui:mt-auto vkui:shrink-0">
             {!noBotArea && (
               <TabsTrigger value="bot">
                 <BotIcon />

--- a/src/visualizers/CircularWaveform/index.tsx
+++ b/src/visualizers/CircularWaveform/index.tsx
@@ -204,7 +204,7 @@ const CircularWaveform = ({
     <div
       ref={containerRef}
       className={cn(
-        "circular-waveform-container w-full h-full flex items-center justify-center",
+        "circular-waveform-container vkui:w-full vkui:h-full vkui:flex vkui:items-center vkui:justify-center",
         className,
       )}
       style={{ position: "relative" }}


### PR DESCRIPTION
This sets up tailwind to use the `vkui` prefix and replaces all occurrences of tailwind class names with the prefixed one.

The downside is that we have to use the prefixed class names in the codebase. We might get rid of that once there are stable build tools for auto-prefixing tailwind v4 class names at build-time.

For now this is a reliable approach to avoid tailwind conflicts.