### PR TITLE
Disconnect Console when unmounted

### DIFF
--- a/src/components/elements/AudioOutput.tsx
+++ b/src/components/elements/AudioOutput.tsx
@@ -35,7 +35,10 @@ export const AudioOutput: React.FC<AudioOutputProps> = ({ className }) => {
         value={selectedSpeaker?.deviceId || ""}
         onValueChange={handleDeviceChange}
       >
-        <SelectTrigger id={id} className={cn("vkui:border-none vkui:w-full", className)}>
+        <SelectTrigger
+          id={id}
+          className={cn("vkui:border-none vkui:w-full", className)}
+        >
           <SelectValue placeholder="Select a speaker" />
         </SelectTrigger>
         <SelectContent align="end">

--- a/src/components/elements/Conversation.tsx
+++ b/src/components/elements/Conversation.tsx
@@ -60,15 +60,21 @@ export const Conversation: React.FC = () => {
 
   if (messages.length > 0) {
     return (
-      <div ref={scrollRef} className="vkui:h-full vkui:overflow-y-auto vkui:p-4">
+      <div
+        ref={scrollRef}
+        className="vkui:h-full vkui:overflow-y-auto vkui:p-4"
+      >
         <div className="vkui:grid vkui:grid-cols-[min-content_1fr] vkui:gap-x-4 vkui:gap-y-2">
           {messages.map((message, index) => (
             <Fragment key={index}>
               <div
-                className={cn("vkui:font-semibold vkui:font-mono vkui:text-xs vkui:leading-6", {
-                  "vkui:text-blue-500": message.role === "user",
-                  "vkui:text-purple-500": message.role === "assistant",
-                })}
+                className={cn(
+                  "vkui:font-semibold vkui:font-mono vkui:text-xs vkui:leading-6",
+                  {
+                    "vkui:text-blue-500": message.role === "user",
+                    "vkui:text-purple-500": message.role === "assistant",
+                  },
+                )}
               >
                 {message.role}
               </div>

--- a/src/components/elements/CopyText.tsx
+++ b/src/components/elements/CopyText.tsx
@@ -33,7 +33,12 @@ export const CopyText: React.FC<CopyTextProps> = ({
   };
 
   return (
-    <div className={cn("vkui:flex vkui:items-center vkui:overflow-hidden vkui:w-full", className)}>
+    <div
+      className={cn(
+        "vkui:flex vkui:items-center vkui:overflow-hidden vkui:w-full",
+        className,
+      )}
+    >
       <span className="vkui:truncate vkui:min-w-0">{text}</span>
       <TooltipProvider>
         <Tooltip>

--- a/src/components/elements/SessionInfo.tsx
+++ b/src/components/elements/SessionInfo.tsx
@@ -26,7 +26,11 @@ export const SessionInfo: React.FC<{
       data={{
         Transport: transportTypeName,
         "Session ID": sessionId ? (
-          <CopyText className="vkui:justify-end" iconSize={12} text={sessionId} />
+          <CopyText
+            className="vkui:justify-end"
+            iconSize={12}
+            text={sessionId}
+          />
         ) : (
           "---"
         ),

--- a/src/components/panels/BotVideoPanel.tsx
+++ b/src/components/panels/BotVideoPanel.tsx
@@ -45,7 +45,9 @@ export const BotVideoPanel: React.FC<BotVideoPanelProps> = ({
         {!track && (
           <div className="vkui:absolute vkui:inset-0 vkui:flex vkui:gap-1 vkui:items-center vkui:justify-center">
             <VideoOffIcon size={16} />
-            {!collapsed && <span className="vkui:font-mono vkui:text-xs">No video</span>}
+            {!collapsed && (
+              <span className="vkui:font-mono vkui:text-xs">No video</span>
+            )}
           </div>
         )}
       </PanelContent>

--- a/src/components/panels/ConversationPanel.tsx
+++ b/src/components/panels/ConversationPanel.tsx
@@ -20,7 +20,10 @@ export const ConversationPanel: React.FC<Props> = ({
         <PanelHeader>
           <TabsList>
             {!noConversation && (
-              <TabsTrigger className="vkui:text-mono-upper" value="conversation">
+              <TabsTrigger
+                className="vkui:text-mono-upper"
+                value="conversation"
+              >
                 <MessagesSquareIcon size={16} />
                 Conversation
               </TabsTrigger>

--- a/src/components/panels/InfoPanel.tsx
+++ b/src/components/panels/InfoPanel.tsx
@@ -36,7 +36,10 @@ export const InfoPanel: React.FC<Props> = ({
       </PanelContent>
       {!noDevices && (
         <>
-          <PanelHeader className="vkui:border-t vkui:border-t-border" variant="inline">
+          <PanelHeader
+            className="vkui:border-t vkui:border-t-border"
+            variant="inline"
+          >
             <PanelTitle>Devices</PanelTitle>
           </PanelHeader>
           <PanelContent>
@@ -46,7 +49,10 @@ export const InfoPanel: React.FC<Props> = ({
           </PanelContent>
         </>
       )}
-      <PanelHeader className="vkui:border-t vkui:border-t-border" variant="inline">
+      <PanelHeader
+        className="vkui:border-t vkui:border-t-border"
+        variant="inline"
+      >
         <PanelTitle>Session</PanelTitle>
       </PanelHeader>
       <PanelContent>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "vkui:bg-primary vkui:text-primary-foreground vkui:hover:bg-primary/90",
+        default:
+          "vkui:bg-primary vkui:text-primary-foreground vkui:hover:bg-primary/90",
         destructive:
           "vkui:bg-destructive vkui:text-white vkui:hover:bg-destructive/90 vkui:focus-visible:ring-destructive/20 vkui:dark:focus-visible:ring-destructive/40 vkui:dark:bg-destructive/60",
         outline:

--- a/src/components/ui/buttongroup.tsx
+++ b/src/components/ui/buttongroup.tsx
@@ -1,19 +1,22 @@
 import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
-const buttonGroupVariants = cva("vkui:flex vkui:items-center vkui:*:rounded-none", {
-  variants: {
-    orientation: {
-      horizontal:
-        "vkui:flex-row vkui:*:first:rounded-s-md vkui:*:last:rounded-e-md vkui:*:-ml-[1px] vkui:*:first:ml-0",
-      vertical:
-        "vkui:flex-col vkui:*:first:rounded-t-md vkui:*:last:rounded-b-md vkui:*:-mt-[1px] vkui:*:first:mt-0",
+const buttonGroupVariants = cva(
+  "vkui:flex vkui:items-center vkui:*:rounded-none",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "vkui:flex-row vkui:*:first:rounded-s-md vkui:*:last:rounded-e-md vkui:*:-ml-[1px] vkui:*:first:ml-0",
+        vertical:
+          "vkui:flex-col vkui:*:first:rounded-t-md vkui:*:last:rounded-b-md vkui:*:-mt-[1px] vkui:*:first:mt-0",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
     },
   },
-  defaultVariants: {
-    orientation: "horizontal",
-  },
-});
+);
 
 export const ButtonGroup = ({
   className,
@@ -23,7 +26,11 @@ export const ButtonGroup = ({
 }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) => {
   return (
     <div
-      className={cn("vkui:flex", buttonGroupVariants({ orientation }), className)}
+      className={cn(
+        "vkui:flex",
+        buttonGroupVariants({ orientation }),
+        className,
+      )}
       {...props}
     >
       {children}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -19,7 +19,10 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
-      className={cn("vkui:flex vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3", className)}
+      className={cn(
+        "vkui:flex vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3",
+        className,
+      )}
       {...props}
     />
   );
@@ -72,7 +75,10 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("vkui:flex vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3", className)}
+      className={cn(
+        "vkui:flex vkui:gap-2 vkui:md:gap-3 vkui:p-2 vkui:md:p-3",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/components/ui/panel.tsx
+++ b/src/components/ui/panel.tsx
@@ -21,7 +21,8 @@ const PanelHeaderVariants = cva("vkui:@container/panel-header", {
     variant: {
       default:
         "vkui:border-b vkui:flex vkui:items-center vkui:justify-center vkui:text-card-foreground vkui:p-2 vkui:@xs/panel:p-3 vkui:@md/panel:p-4",
-      inline: "vkui:items-start vkui:text-foreground vkui:p-2 vkui:@xs/panel:p-3 vkui:@md/panel:p-4",
+      inline:
+        "vkui:items-start vkui:text-foreground vkui:p-2 vkui:@xs/panel:p-3 vkui:@md/panel:p-4",
     },
   },
   defaultVariants: {
@@ -83,7 +84,10 @@ function PanelActions({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="panel-actions"
-      className={cn("vkui:flex vkui:items-center vkui:gap-1 vkui:@xs/panel:gap-2", className)}
+      className={cn(
+        "vkui:flex vkui:items-center vkui:gap-1 vkui:@xs/panel:gap-2",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -16,7 +16,8 @@ const selectTriggerVariants = cva(
   {
     variants: {
       size: {
-        default: "vkui:h-8 vkui:pl-3 vkui:pr-2.5 vkui:py-2 vkui:gap-2 vkui:[&_svg]:size-3.5",
+        default:
+          "vkui:h-8 vkui:pl-3 vkui:pr-2.5 vkui:py-2 vkui:gap-2 vkui:[&_svg]:size-3.5",
         sm: "vkui:h-7 vkui:pl-3 vkui:pr-2.5 vkui:py-1.5 vkui:gap-2 vkui:[&_svg]:size-3.5",
         lg: "vkui:h-10 vkui:px-3.5 vkui:py-2.5 vkui:gap-3 vkui:[&_svg]:size-4",
       },
@@ -56,7 +57,11 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
-      className={cn(selectTriggerVariants({ size }), "vkui:truncate", className)}
+      className={cn(
+        selectTriggerVariants({ size }),
+        "vkui:truncate",
+        className,
+      )}
       {...props}
     >
       <span className="vkui:truncate vkui:flex-1 vkui:min-w-0">{children}</span>
@@ -143,7 +148,10 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("vkui:bg-border vkui:pointer-events-none vkui:-mx-1 vkui:my-1 vkui:h-px", className)}
+      className={cn(
+        "vkui:bg-border vkui:pointer-events-none vkui:-mx-1 vkui:my-1 vkui:h-px",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/templates/Console/index.tsx
+++ b/src/templates/Console/index.tsx
@@ -275,7 +275,9 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
               color={resolvedTheme === "dark" ? "#ffffff" : "#171717"}
             />
           )}
-          <strong className="vkui:hidden vkui:sm:block vkui:text-center">{title}</strong>
+          <strong className="vkui:hidden vkui:sm:block vkui:text-center">
+            {title}
+          </strong>
           <div className="vkui:flex vkui:items-center vkui:justify-end vkui:gap-4">
             {!noThemeSwitch && <ThemeModeToggle />}
             <ConnectButton
@@ -303,7 +305,8 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                       {!noBotAudio && (
                         <BotAudioPanel
                           className={cn({
-                            "vkui:max-h-[calc(50%-4px)] vkui:mt-auto": !noBotVideo,
+                            "vkui:max-h-[calc(50%-4px)] vkui:mt-auto":
+                              !noBotVideo,
                           })}
                           collapsed={isBotAreaCollapsed}
                         />
@@ -311,7 +314,8 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                       {!noBotVideo && (
                         <BotVideoPanel
                           className={cn({
-                            "vkui:max-h-[calc(50%-4px)] vkui:mb-auto": !noBotAudio,
+                            "vkui:max-h-[calc(50%-4px)] vkui:mb-auto":
+                              !noBotAudio,
                           })}
                           collapsed={isBotAreaCollapsed}
                         />
@@ -439,7 +443,10 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                 />
               </TabsContent>
             )}
-            <TabsContent value="info" className="vkui:flex-1 vkui:overflow-auto vkui:p-2">
+            <TabsContent
+              value="info"
+              className="vkui:flex-1 vkui:overflow-auto vkui:p-2"
+            >
               <InfoPanel
                 noAudioOutput={noAudioOutput}
                 noUserAudio={noUserAudio}
@@ -448,7 +455,10 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                 sessionId={sessionId}
               />
             </TabsContent>
-            <TabsContent value="events" className="vkui:flex-1 vkui:overflow-auto">
+            <TabsContent
+              value="events"
+              className="vkui:flex-1 vkui:overflow-auto"
+            >
               <EventsPanel />
             </TabsContent>
           </div>

--- a/src/templates/Console/index.tsx
+++ b/src/templates/Console/index.tsx
@@ -43,8 +43,7 @@ import {
 import { RTVIClientAudio, RTVIClientProvider } from "@pipecat-ai/client-react";
 import { DailyTransport } from "@pipecat-ai/daily-transport";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
-import deepEqual from "fast-deep-equal";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 export interface ConsoleTemplateProps {
   /**
@@ -148,93 +147,93 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
   const [rtviClient, setRtviClient] = useState<RTVIClient | null>(null);
   const [isClientReady, setIsClientReady] = useState(false);
 
-  const clientRef = useRef<RTVIClient | null>(null);
-  const previousClientOptions = useRef<Partial<RTVIClientOptions>>({});
-
   const { resolvedTheme } = useTheme();
 
-  useEffect(() => {
-    if (!deepEqual(previousClientOptions.current, clientOptions)) {
-      clientRef.current = null;
-    }
-    previousClientOptions.current = clientOptions;
-  }, [clientOptions]);
+  useEffect(
+    function initClient() {
+      // Only run on client side
+      if (typeof window === "undefined") return;
 
-  useEffect(() => {
-    // Only run on client side
-    if (typeof window === "undefined") return;
-
-    if (clientRef.current) {
-      setRtviClient(clientRef.current);
-      setIsClientReady(true);
-      return;
-    }
-
-    let transport: DailyTransport | SmallWebRTCTransport;
-    switch (transportType) {
-      case "smallwebrtc":
-        transport = new SmallWebRTCTransport();
-        if (audioCodec) {
-          transport.setAudioCodec(audioCodec);
-        }
-        if (videoCodec) {
-          transport.setVideoCodec(videoCodec);
-        }
-        break;
-      case "daily":
-      default:
-        transport = new DailyTransport();
-        transport.dailyCallClient.on("meeting-session-updated", (event) => {
-          setSessionId(event.meetingSession.id);
-        });
-        break;
-    }
-    const client = new RTVIClient({
-      enableCam: !noUserVideo,
-      enableMic: !noUserAudio,
-      customConnectHandler: (async (_params, timeout) => {
-        if (transportType === "smallwebrtc") {
-          return Promise.resolve();
-        }
-        try {
-          const response = await onConnect();
-          clearTimeout(timeout);
-          if (response.ok) {
-            return response.json();
+      let transport: DailyTransport | SmallWebRTCTransport;
+      switch (transportType) {
+        case "smallwebrtc":
+          transport = new SmallWebRTCTransport();
+          break;
+        case "daily":
+        default:
+          transport = new DailyTransport();
+          transport.dailyCallClient.on("meeting-session-updated", (event) => {
+            setSessionId(event.meetingSession.id);
+          });
+          break;
+      }
+      const client = new RTVIClient({
+        enableCam: !noUserVideo,
+        enableMic: !noUserAudio,
+        customConnectHandler: (async (_params, timeout) => {
+          if (transportType === "smallwebrtc") {
+            return Promise.resolve();
           }
-          return Promise.reject(
-            new Error(`Connection failed: ${response.status}`),
-          );
-        } catch (err) {
-          return Promise.reject(err);
-        }
-      }) as (
-        params: RTVIClientParams,
-        timeout: NodeJS.Timeout | undefined,
-        abortController: AbortController,
-      ) => Promise<void>,
-      ...clientOptions,
-      params: {
-        ...(clientOptions.params ?? defaultParams),
-      },
-      transport: (clientOptions?.transport as Transport) ?? transport,
-      callbacks: {
-        onParticipantJoined: (participant) => {
-          setParticipantId(participant.id || "");
-          clientOptions?.callbacks?.onParticipantJoined?.(participant);
+          try {
+            const response = await onConnect();
+            clearTimeout(timeout);
+            if (response.ok) {
+              return response.json();
+            }
+            return Promise.reject(
+              new Error(`Connection failed: ${response.status}`),
+            );
+          } catch (err) {
+            return Promise.reject(err);
+          }
+        }) as (
+          params: RTVIClientParams,
+          timeout: NodeJS.Timeout | undefined,
+          abortController: AbortController,
+        ) => Promise<void>,
+        ...clientOptions,
+        params: {
+          ...(clientOptions.params ?? defaultParams),
         },
-        onTrackStarted(track, participant) {
-          if (participant?.id && participant.local)
-            setParticipantId(participant.id);
-          clientOptions?.callbacks?.onTrackStarted?.(track, participant);
+        transport: (clientOptions?.transport as Transport) ?? transport,
+        callbacks: {
+          onParticipantJoined: (participant) => {
+            setParticipantId(participant.id || "");
+            clientOptions?.callbacks?.onParticipantJoined?.(participant);
+          },
+          onTrackStarted(track, participant) {
+            if (participant?.id && participant.local)
+              setParticipantId(participant.id);
+            clientOptions?.callbacks?.onTrackStarted?.(track, participant);
+          },
         },
-      },
-    });
-    client.initDevices();
-    clientRef.current = client;
-    setRtviClient(client);
-    setIsClientReady(true);
-  }, [audioCodec, clientOptions, onConnect, transportType, videoCodec]);
+      });
+      client.initDevices();
+      setRtviClient(client);
+      setIsClientReady(true);
+      return () => {
+        /**
+         * Disconnect client when component unmounts or options change.
+         */
+        client.disconnect();
+      };
+    },
+    [clientOptions, noUserAudio, noUserVideo, onConnect, transportType],
+  );
+
+  useEffect(
+    function updateSmallWebRTCCodecs() {
+      if (!rtviClient || transportType !== "smallwebrtc") return;
+      const transport = rtviClient.transport as SmallWebRTCTransport;
+      if (audioCodec) {
+        transport.setAudioCodec(audioCodec);
+      }
+      if (videoCodec) {
+        transport.setVideoCodec(videoCodec);
+      }
+    },
+    [audioCodec, rtviClient, videoCodec, transportType],
+  );
 
   const handleConnect = async () => {
     if (!rtviClient) return;


### PR DESCRIPTION
Fixes #14.

When the Console component is unmounted, it will now also disconnect properly. This ensures that no lingering WebRTC connections stay connected in the browser, leading to the browser still reporting camera and/or microphone usage for the tab that rendered the Console template.