### PR TITLE
Add noSessionInfo & noStatusInfo props + fix clientOptions stable reference

### DIFF
--- a/src/components/panels/InfoPanel.tsx
+++ b/src/components/panels/InfoPanel.tsx
@@ -12,6 +12,8 @@ import {
 
 interface Props {
   noAudioOutput?: boolean;
+  noSessionInfo?: boolean;
+  noStatusInfo?: boolean;
   noUserAudio?: boolean;
   noUserVideo?: boolean;
   participantId?: string;
@@ -20,20 +22,30 @@ interface Props {
 
 export const InfoPanel: React.FC<Props> = ({
   noAudioOutput = false,
+  noSessionInfo = false,
+  noStatusInfo = false,
   noUserAudio = false,
   noUserVideo = false,
   participantId,
   sessionId,
 }) => {
   const noDevices = noAudioOutput && noUserAudio && noUserVideo;
+  const noInfoPanel = noStatusInfo && noDevices && noSessionInfo;
+
+  if (noInfoPanel) return null;
+
   return (
     <Panel className="vkui:h-full vkui:overflow-y-auto vkui:overflow-x-hidden">
-      <PanelHeader variant="inline">
-        <PanelTitle>Status</PanelTitle>
-      </PanelHeader>
-      <PanelContent>
-        <ClientStatus />
-      </PanelContent>
+      {!noStatusInfo && (
+        <>
+          <PanelHeader variant="inline">
+            <PanelTitle>Status</PanelTitle>
+          </PanelHeader>
+          <PanelContent>
+            <ClientStatus />
+          </PanelContent>
+        </>
+      )}
       {!noDevices && (
         <>
           <PanelHeader
@@ -49,15 +61,19 @@ export const InfoPanel: React.FC<Props> = ({
           </PanelContent>
         </>
       )}
-      <PanelHeader
-        className="vkui:border-t vkui:border-t-border"
-        variant="inline"
-      >
-        <PanelTitle>Session</PanelTitle>
-      </PanelHeader>
-      <PanelContent>
-        <SessionInfo sessionId={sessionId} participantId={participantId} />
-      </PanelContent>
+      {!noSessionInfo && (
+        <>
+          <PanelHeader
+            className="vkui:border-t vkui:border-t-border"
+            variant="inline"
+          >
+            <PanelTitle>Session</PanelTitle>
+          </PanelHeader>
+          <PanelContent>
+            <SessionInfo sessionId={sessionId} participantId={participantId} />
+          </PanelContent>
+        </>
+      )}
     </Panel>
   );
 };

--- a/src/templates/Console/index.tsx
+++ b/src/templates/Console/index.tsx
@@ -120,11 +120,13 @@ const defaultParams: RTVIClientParams = {
   baseUrl: "noop",
 };
 
+const defaultClientOptions: Partial<RTVIClientOptions> = {
+  params: defaultParams,
+};
+
 export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
   audioCodec = "default",
-  clientOptions = {
-    params: defaultParams,
-  },
+  clientOptions = defaultClientOptions,
   onConnect,
   noAudioOutput = false,
   noBotAudio = false,

--- a/src/templates/Console/index.tsx
+++ b/src/templates/Console/index.tsx
@@ -84,6 +84,14 @@ export interface ConsoleTemplateProps {
    */
   noMetrics?: boolean;
   /**
+   * Disables the session info panel.
+   */
+  noSessionInfo?: boolean;
+  /**
+   * Disables the status info panel.
+   */
+  noStatusInfo?: boolean;
+  /**
    * Disables the theme switcher in the header.
    * Useful when there's an application-level theme switcher or when the theme is controlled globally.
    */
@@ -134,6 +142,8 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
   noConversation = false,
   noLogo = false,
   noMetrics = false,
+  noSessionInfo = false,
+  noStatusInfo = false,
   noThemeSwitch = false,
   noUserAudio = false,
   noUserVideo = false,
@@ -263,6 +273,7 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
   const noBotArea = noBotAudio && noBotVideo;
   const noConversationPanel = noConversation && noMetrics;
   const noDevices = noAudioOutput && noUserAudio && noUserVideo;
+  const noInfoPanel = noStatusInfo && noDevices && noSessionInfo;
 
   return (
     <RTVIClientProvider client={rtviClient}>
@@ -322,7 +333,9 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                         />
                       )}
                     </ResizablePanel>
-                    <ResizableHandle withHandle />
+                    {(!noConversationPanel || !noInfoPanel) && (
+                      <ResizableHandle withHandle />
+                    )}
                   </>
                 )}
                 {!noConversationPanel && (
@@ -337,72 +350,80 @@ export const ConsoleTemplate: React.FC<ConsoleTemplateProps> = ({
                         noMetrics={noMetrics}
                       />
                     </ResizablePanel>
-                    <ResizableHandle withHandle />
+                    {!noInfoPanel && <ResizableHandle withHandle />}
                   </>
                 )}
-                <ResizablePanel
-                  id="info-panel"
-                  collapsible
-                  collapsedSize={4}
-                  minSize={15}
-                  defaultSize={20}
-                  onCollapse={() => setIsInfoPanelCollapsed(true)}
-                  onExpand={() => setIsInfoPanelCollapsed(false)}
-                  className="vkui:p-2"
-                >
-                  {isInfoPanelCollapsed ? (
-                    <div className="vkui:flex vkui:flex-col vkui:items-center vkui:justify-center vkui:gap-4 vkui:h-full">
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button variant="ghost" size="icon">
-                            <ChevronsLeftRightEllipsisIcon size={16} />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent side="left">
-                          <ClientStatus />
-                        </PopoverContent>
-                      </Popover>
-                      {!noDevices && (
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <Button variant="ghost" size="icon">
-                              <MicIcon size={16} />
-                            </Button>
-                          </PopoverTrigger>
-                          <PopoverContent
-                            className="vkui:flex vkui:flex-col vkui:gap-2"
-                            side="left"
-                          >
-                            {!noUserAudio && <UserAudio />}
-                            {!noUserVideo && <UserVideo />}
-                            {!noAudioOutput && <AudioOutput />}
-                          </PopoverContent>
-                        </Popover>
-                      )}
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button variant="ghost" size="icon">
-                            <InfoIcon size={16} />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent side="left">
-                          <SessionInfo
-                            sessionId={sessionId}
-                            participantId={participantId}
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                  ) : (
-                    <InfoPanel
-                      noAudioOutput={noAudioOutput}
-                      noUserAudio={noUserAudio}
-                      noUserVideo={noUserVideo}
-                      participantId={participantId}
-                      sessionId={sessionId}
-                    />
-                  )}
-                </ResizablePanel>
+                {!noInfoPanel && (
+                  <ResizablePanel
+                    id="info-panel"
+                    collapsible
+                    collapsedSize={4}
+                    minSize={15}
+                    defaultSize={20}
+                    onCollapse={() => setIsInfoPanelCollapsed(true)}
+                    onExpand={() => setIsInfoPanelCollapsed(false)}
+                    className="vkui:p-2"
+                  >
+                    {isInfoPanelCollapsed ? (
+                      <div className="vkui:flex vkui:flex-col vkui:items-center vkui:justify-center vkui:gap-4 vkui:h-full">
+                        {!noStatusInfo && (
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <Button variant="ghost" size="icon">
+                                <ChevronsLeftRightEllipsisIcon size={16} />
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent side="left">
+                              <ClientStatus />
+                            </PopoverContent>
+                          </Popover>
+                        )}
+                        {!noDevices && (
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <Button variant="ghost" size="icon">
+                                <MicIcon size={16} />
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                              className="vkui:flex vkui:flex-col vkui:gap-2"
+                              side="left"
+                            >
+                              {!noUserAudio && <UserAudio />}
+                              {!noUserVideo && <UserVideo />}
+                              {!noAudioOutput && <AudioOutput />}
+                            </PopoverContent>
+                          </Popover>
+                        )}
+                        {!noSessionInfo && (
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <Button variant="ghost" size="icon">
+                                <InfoIcon size={16} />
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent side="left">
+                              <SessionInfo
+                                sessionId={sessionId}
+                                participantId={participantId}
+                              />
+                            </PopoverContent>
+                          </Popover>
+                        )}
+                      </div>
+                    ) : (
+                      <InfoPanel
+                        noAudioOutput={noAudioOutput}
+                        noSessionInfo={noSessionInfo}
+                        noStatusInfo={noStatusInfo}
+                        noUserAudio={noUserAudio}
+                        noUserVideo={noUserVideo}
+                        participantId={participantId}
+                        sessionId={sessionId}
+                      />
+                    )}
+                  </ResizablePanel>
+                )}
               </ResizablePanelGroup>
             </ResizablePanel>
             <ResizableHandle withHandle />


### PR DESCRIPTION
This adds two new props `noSessionInfo` and `noStatusInfo`. This allows to hide the info panel entirely.
I also fixed an issue with the default value for `clientOptions`, which led to an infinite render loop because it wasn't using a stable reference.

Fixes #9.