### PR TITLE
Migrate to Pipecat clients 1.0.0

### DIFF
--- a/examples/01-console/src/app/api/connect/route.ts
+++ b/examples/01-console/src/app/api/connect/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-export async function POST(request: NextRequest) {
+export async function POST() {
   // Check if required environment variables are set
   if (!process.env.BOT_START_URL) {
     return NextResponse.json(
@@ -10,8 +10,6 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const body = await request.json();
-
     // Prepare headers - make API key optional
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -26,7 +24,9 @@ export async function POST(request: NextRequest) {
       method: "POST",
       mode: "cors",
       headers,
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        createDailyRoom: true,
+      }),
     });
 
     if (!response.ok) {
@@ -39,7 +39,10 @@ export async function POST(request: NextRequest) {
       throw new Error(data.error);
     }
 
-    return NextResponse.json(data, { status: 200 });
+    return NextResponse.json({
+      room_url: data.dailyRoom,
+      token: data.dailyToken,
+    }, { status: 200 });
   } catch (error) {
     return NextResponse.json(
       { error: `Failed to process connection request: ${error}` },

--- a/examples/01-console/src/app/page.tsx
+++ b/examples/01-console/src/app/page.tsx
@@ -7,31 +7,10 @@ export default function Home() {
     <ThemeProvider>
       <div className="w-full h-dvh bg-background">
         <ConsoleTemplate
-          transportType="daily"
-          onConnect={async () => {
-            // Call the connect serverless function and get the room URL and token from Daily
-            const response = await fetch("/api/connect", {
-              method: "POST",
-              body: JSON.stringify({
-                createDailyRoom: true,
-              }),
-            });
-            if (!response.ok) {
-              throw new Error("Failed to connect to Pipecat");
-            }
-            const data = await response.json();
-            if (data.error) {
-              throw new Error(data.error);
-            }
-
-            return new Response(
-              JSON.stringify({
-                room_url: data.dailyRoom,
-                token: data.dailyToken,
-              }),
-              { status: 200 },
-            );
+          connectParams={{
+            endpoint: "/api/connect",
           }}
+          transportType="daily"
         />
       </div>
     </ThemeProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.3",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@daily-co/daily-js": "^0.79.0",
-        "@pipecat-ai/client-js": "^0.4.1",
-        "@pipecat-ai/client-react": "^0.4.1",
-        "@pipecat-ai/daily-transport": "^0.4.0",
-        "@pipecat-ai/small-webrtc-transport": "^0.4.0",
+        "@daily-co/daily-js": "^0.80.0",
+        "@pipecat-ai/client-js": "^1.0.0",
+        "@pipecat-ai/client-react": "^1.0.0",
+        "@pipecat-ai/daily-transport": "^1.0.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.0.0",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.79.0.tgz",
-      "integrity": "sha512-Ii/Zi6cfTl2EZBpX8msRPNkkCHcajA+ErXpbN2Xe2KySd1Nb4IzC/QWJlSl9VA9pIlYPQicRTDoZnoym/0uEAw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.80.0.tgz",
+      "integrity": "sha512-zG2NBbKbHfm56P0lg4ddC94vBtn5AQKcgvbYrO5+ohNWPSolMqlJiYxQC9uhOHfFYRhH4ELKQ6NHqGatX9VD7A==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@sentry/browser": "^8.33.1",
@@ -1631,11 +1631,12 @@
       "dev": true
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-0.4.1.tgz",
-      "integrity": "sha512-3jLKRzeryqLxtkqvr4Bvxe2OxoI7mdOFecm6iolZizXnk/BE480SEg2oAKyov3b5oT6+jmPlT+1HRBlTzEtL7A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.0.0.tgz",
+      "integrity": "sha512-c+LtwyG7KlEPxDImXnxlNrFIlq0I3nd6R3gmLHfDr3fAq5zmlOrzZCeOPWWRhPFvBO+MNSoVrmNeDv6DJWsMPA==",
       "dependencies": {
         "@types/events": "^3.0.3",
+        "bowser": "^2.11.0",
         "clone-deep": "^4.0.1",
         "events": "^3.3.0",
         "typed-emitter": "^2.1.0",
@@ -1643,9 +1644,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-react": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-0.4.1.tgz",
-      "integrity": "sha512-7bzSOma8L2UPW/Cp8uOFEDbggRMm/XErzkQNopXYfr4/5QMmLikAuzJOCwwXo5zewVczUUFtinFmqZT2B5VwDQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-1.0.0.tgz",
+      "integrity": "sha512-vhyKeFnQlN6311w4f+g+45rLQcn6Qmd5CI933T7wV8Yti8qHi2Tf54mQ9CS7X1lU0wgl7KLDMi/8p+7JaUoTfg==",
       "dependencies": {
         "jotai": "^2.9.0"
       },
@@ -1656,14 +1657,14 @@
       }
     },
     "node_modules/@pipecat-ai/daily-transport": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/daily-transport/-/daily-transport-0.4.0.tgz",
-      "integrity": "sha512-qPiLwAILBpPY3nUYxpEl4bdvtP+qIb/GwjKugyw3LVbC4HkD5Q5nav0GgKMPNTXIbK08YDCJbAWZhnqzTcmuyw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/daily-transport/-/daily-transport-1.0.0.tgz",
+      "integrity": "sha512-iXmv9Et/TGPvJoeOY+ZBPv+a3pbqT502jco2MBHl8l2VrtztkidjDwiOkPfPdD191CCwaSbV5laSYALsD0AyxA==",
       "dependencies": {
         "@daily-co/daily-js": "^0.77.0"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.4.0"
+        "@pipecat-ai/client-js": "~1.0.0"
       }
     },
     "node_modules/@pipecat-ai/daily-transport/node_modules/@daily-co/daily-js": {
@@ -1682,15 +1683,15 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-0.4.0.tgz",
-      "integrity": "sha512-t/7Y6Du3+GCjBj71xo/snlEEkV7CizJZPLQEyyBoXp4uvW3ciT8WVxsDvPk2QGWiarEZMZ/khUCNGDHKHAHuwA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.0.0.tgz",
+      "integrity": "sha512-JRXepnMN9w0thxjrpdzvoR6pn8MoC+J8lywnMHzAOifGGhlrA6ZSgMQtoRjiXs7PdjDFOkAT4mAdJrte0dC00A==",
       "dependencies": {
         "@daily-co/daily-js": "^0.77.0",
         "dequal": "^2.0.3"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.4.0"
+        "@pipecat-ai/client-js": "~1.0.0"
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport/node_modules/@daily-co/daily-js": {

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "ladle": "npx ladle serve"
   },
   "dependencies": {
-    "@daily-co/daily-js": "^0.79.0",
-    "@pipecat-ai/client-js": "^0.4.1",
-    "@pipecat-ai/client-react": "^0.4.1",
-    "@pipecat-ai/daily-transport": "^0.4.0",
-    "@pipecat-ai/small-webrtc-transport": "^0.4.0",
+    "@daily-co/daily-js": "^0.80.0",
+    "@pipecat-ai/client-js": "^1.0.0",
+    "@pipecat-ai/client-react": "^1.0.0",
+    "@pipecat-ai/daily-transport": "^1.0.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.0.0",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",

--- a/src/components/elements/AudioOutput.tsx
+++ b/src/components/elements/AudioOutput.tsx
@@ -1,5 +1,5 @@
 import React, { useId } from "react";
-import { useRTVIClientMediaDevices } from "@pipecat-ai/client-react";
+import { usePipecatClientMediaDevices } from "@pipecat-ai/client-react";
 import {
   Select,
   SelectContent,
@@ -15,7 +15,7 @@ interface AudioOutputProps {
 
 export const AudioOutput: React.FC<AudioOutputProps> = ({ className }) => {
   const { availableSpeakers, selectedSpeaker, updateSpeaker } =
-    useRTVIClientMediaDevices();
+    usePipecatClientMediaDevices();
 
   const handleDeviceChange = (deviceId: string) => {
     updateSpeaker(deviceId);

--- a/src/components/elements/ClientStatus.tsx
+++ b/src/components/elements/ClientStatus.tsx
@@ -1,6 +1,6 @@
 import {
+  usePipecatClientTransportState,
   useRTVIClientEvent,
-  useRTVIClientTransportState,
 } from "@pipecat-ai/client-react";
 import DataList from "@/components/elements/DataList";
 import { cn } from "@/lib/utils";
@@ -8,7 +8,7 @@ import { RTVIEvent } from "@pipecat-ai/client-js";
 import { useState } from "react";
 
 export const ClientStatus: React.FC = () => {
-  const transportState = useRTVIClientTransportState();
+  const transportState = usePipecatClientTransportState();
 
   const agentConnecting =
     transportState === "connecting" ||

--- a/src/components/elements/ConnectButton.tsx
+++ b/src/components/elements/ConnectButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { useRTVIClientTransportState } from "@pipecat-ai/client-react";
+import { usePipecatClientTransportState } from "@pipecat-ai/client-react";
 import { cn } from "@/lib/utils";
 
 export type ConnectButtonProps = {
@@ -16,7 +16,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
   onConnect,
   onDisconnect,
 }) => {
-  const transportState = useRTVIClientTransportState();
+  const transportState = usePipecatClientTransportState();
 
   const getButtonProps = (): React.ComponentProps<typeof Button> => {
     switch (transportState) {

--- a/src/components/elements/Conversation.tsx
+++ b/src/components/elements/Conversation.tsx
@@ -1,4 +1,4 @@
-import { useRTVIClientTransportState } from "@pipecat-ai/client-react";
+import { usePipecatClientTransportState } from "@pipecat-ai/client-react";
 import { Fragment, useCallback, useEffect, useRef } from "react";
 import useConversation from "@/hooks/useConversation";
 import { cn } from "@/lib/utils";
@@ -8,7 +8,7 @@ export const Conversation: React.FC = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottom = useRef(true);
 
-  const transportState = useRTVIClientTransportState();
+  const transportState = usePipecatClientTransportState();
 
   const maybeScrollToBottom = useCallback(() => {
     if (!scrollRef.current) return;

--- a/src/components/elements/Metrics.tsx
+++ b/src/components/elements/Metrics.tsx
@@ -1,7 +1,7 @@
 import { RTVIEvent } from "@pipecat-ai/client-js";
 import {
+  usePipecatClientTransportState,
   useRTVIClientEvent,
-  useRTVIClientTransportState,
 } from "@pipecat-ai/client-react";
 import { useState } from "react";
 import { Line } from "react-chartjs-2";
@@ -52,7 +52,7 @@ export const Metrics: React.FC = () => {
   const [metrics, setMetrics] = useState<MetricsState>({});
   const [tokenMetrics, setTokenMetrics] = useState<Partial<TokenMetrics>>({});
 
-  const transportState = useRTVIClientTransportState();
+  const transportState = usePipecatClientTransportState();
 
   useRTVIClientEvent(RTVIEvent.Connected, () => {
     setMetrics({});

--- a/src/components/elements/SessionInfo.tsx
+++ b/src/components/elements/SessionInfo.tsx
@@ -1,20 +1,20 @@
 import CopyText from "@/components/elements/CopyText";
 import DataList from "@/components/elements/DataList";
 import Daily from "@daily-co/daily-js";
-import { useRTVIClient } from "@pipecat-ai/client-react";
+import { usePipecatClient } from "@pipecat-ai/client-react";
 
 export const SessionInfo: React.FC<{
   sessionId?: string;
   participantId?: string;
 }> = ({ sessionId, participantId }) => {
-  const rtviClient = useRTVIClient();
+  const client = usePipecatClient();
 
   let transportTypeName = "Unknown";
-  if (rtviClient && "dailyCallClient" in rtviClient.transport) {
+  if (client && "dailyCallClient" in client.transport) {
     transportTypeName = `Daily (v${Daily.version()})`;
   } else if (
     // @ts-expect-error - __proto__ not typed
-    rtviClient?.transport.__proto__.constructor.SERVICE_NAME ===
+    client?.transport.__proto__.constructor.SERVICE_NAME ===
     "small-webrtc-transport"
   ) {
     transportTypeName = "Small WebRTC";
@@ -43,7 +43,7 @@ export const SessionInfo: React.FC<{
         ) : (
           "---"
         ),
-        RTVI: rtviClient?.version || "---",
+        RTVI: client?.version || "---",
       }}
     />
   );

--- a/src/components/elements/UserAudio.tsx
+++ b/src/components/elements/UserAudio.tsx
@@ -10,16 +10,17 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDownIcon, MicIcon, MicOffIcon } from "@/icons";
 import {
-  RTVIClientMicToggle,
-  useRTVIClient,
-  useRTVIClientMediaDevices,
+  PipecatClientMicToggle,
+  usePipecatClient,
+  usePipecatClientMediaDevices,
   VoiceVisualizer,
 } from "@pipecat-ai/client-react";
 import { memo, useEffect } from "react";
 
 const UserAudio: React.FC = () => {
-  const client = useRTVIClient();
-  const { availableMics, selectedMic, updateMic } = useRTVIClientMediaDevices();
+  const client = usePipecatClient();
+  const { availableMics, selectedMic, updateMic } =
+    usePipecatClientMediaDevices();
 
   // @ts-expect-error _options is protected, but can be totally accessed in JS
   const hasAudio = client?._options?.enableMic;
@@ -44,7 +45,7 @@ const UserAudio: React.FC = () => {
   return (
     <div className="vkui:flex vkui:flex-col vkui:gap-2">
       <ButtonGroup className="vkui:w-full">
-        <RTVIClientMicToggle>
+        <PipecatClientMicToggle>
           {({ isMicEnabled, onClick }) => (
             <Button
               onClick={onClick}
@@ -64,7 +65,7 @@ const UserAudio: React.FC = () => {
               />
             </Button>
           )}
-        </RTVIClientMicToggle>
+        </PipecatClientMicToggle>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/src/components/elements/UserVideo.tsx
+++ b/src/components/elements/UserVideo.tsx
@@ -9,16 +9,17 @@ import {
 import { ChevronDownIcon, VideoIcon, VideoOffIcon } from "@/icons";
 import { cn } from "@/lib/utils";
 import {
-  RTVIClientCamToggle,
-  RTVIClientVideo,
-  useRTVIClientMediaDevices,
+  PipecatClientCamToggle,
+  PipecatClientVideo,
+  usePipecatClientMediaDevices,
 } from "@pipecat-ai/client-react";
 
 export const UserVideo: React.FC = () => {
-  const { availableCams, selectedCam, updateCam } = useRTVIClientMediaDevices();
+  const { availableCams, selectedCam, updateCam } =
+    usePipecatClientMediaDevices();
 
   return (
-    <RTVIClientCamToggle>
+    <PipecatClientCamToggle>
       {({ isCamEnabled, onClick }) => (
         <div
           className={cn("vkui:bg-muted vkui:rounded-xl vkui:relative", {
@@ -26,7 +27,7 @@ export const UserVideo: React.FC = () => {
             "vkui:h-12": !isCamEnabled,
           })}
         >
-          <RTVIClientVideo
+          <PipecatClientVideo
             className={cn("vkui:rounded-xl", {
               "vkui:hidden": !isCamEnabled,
             })}
@@ -66,7 +67,7 @@ export const UserVideo: React.FC = () => {
           </div>
         </div>
       )}
-    </RTVIClientCamToggle>
+    </PipecatClientCamToggle>
   );
 };
 export default UserVideo;

--- a/src/components/panels/BotAudioPanel.tsx
+++ b/src/components/panels/BotAudioPanel.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/ui/panel";
 import { MicOffIcon } from "@/icons";
 import {
-  useRTVIClientMediaTrack,
+  usePipecatClientMediaTrack,
   VoiceVisualizer,
 } from "@pipecat-ai/client-react";
 import { useEffect, useRef, useState } from "react";
@@ -26,7 +26,7 @@ export const BotAudioPanel: React.FC<BotAudioPanelProps> = ({
   className,
   collapsed = false,
 }) => {
-  const track = useRTVIClientMediaTrack("audio", "bot");
+  const track = usePipecatClientMediaTrack("audio", "bot");
 
   const [maxHeight, setMaxHeight] = useState(48);
   const [width, setWidth] = useState(4);

--- a/src/components/panels/BotVideoPanel.tsx
+++ b/src/components/panels/BotVideoPanel.tsx
@@ -7,8 +7,8 @@ import {
 import { VideoOffIcon } from "@/icons";
 import { cn } from "@/lib/utils";
 import {
-  RTVIClientVideo,
-  useRTVIClientMediaTrack,
+  PipecatClientVideo,
+  usePipecatClientMediaTrack,
 } from "@pipecat-ai/client-react";
 
 interface BotVideoPanelProps {
@@ -20,7 +20,7 @@ export const BotVideoPanel: React.FC<BotVideoPanelProps> = ({
   className,
   collapsed = false,
 }) => {
-  const track = useRTVIClientMediaTrack("video", "bot");
+  const track = usePipecatClientMediaTrack("video", "bot");
   return (
     <Panel
       className={cn(className, {
@@ -37,7 +37,7 @@ export const BotVideoPanel: React.FC<BotVideoPanelProps> = ({
           "vkui:p-0!": collapsed,
         })}
       >
-        <RTVIClientVideo
+        <PipecatClientVideo
           participant="bot"
           className="vkui:aspect-video vkui:bg-muted vkui:rounded-sm vkui:max-h-full"
           fit="contain"

--- a/src/components/panels/EventsPanel.tsx
+++ b/src/components/panels/EventsPanel.tsx
@@ -9,9 +9,9 @@ import { FunnelIcon } from "@/icons";
 import { cn } from "@/lib/utils";
 import { RTVIEvent } from "@pipecat-ai/client-js";
 import {
-  useRTVIClient,
+  usePipecatClient,
+  usePipecatClientTransportState,
   useRTVIClientEvent,
-  useRTVIClientTransportState,
 } from "@pipecat-ai/client-react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 
@@ -26,7 +26,7 @@ interface Props {
 }
 
 export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
-  const client = useRTVIClient();
+  const client = usePipecatClient();
   const [events, setEvents] = useState<EventData[]>([]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -44,7 +44,7 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
     });
   }, []);
 
-  const transportState = useRTVIClientTransportState();
+  const transportState = usePipecatClientTransportState();
   const lastTransportState = useRef("");
   useEffect(() => {
     if (transportState === lastTransportState.current) return;
@@ -84,16 +84,8 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
   useRTVIClientEvent(RTVIEvent.BotReady, (botData) => {
     addEvent({
       event: RTVIEvent.BotReady,
-      message: `Bot ready (v${botData.version})`,
+      message: `Bot ready (v${botData.version}): ${JSON.stringify(botData.about ?? {})}`,
       time: new Date().toLocaleTimeString(),
-    });
-    if (!botData.config) return;
-    botData.config.forEach((config) => {
-      addEvent({
-        event: RTVIEvent.BotReady,
-        message: `${config.service}: ${JSON.stringify(config.options)}`,
-        time: new Date().toLocaleTimeString(),
-      });
     });
   });
 


### PR DESCRIPTION
This updates the dependencies to use the Pipecat client libraries ^1.0.0 and updates the code accordingly.
The connection logic in the console template has been simplified in that the `onConnect` prop is removed in favor of a new `connectParams` prop, which is passed to `connect()`.

The console example has been updated, too, to return the correct data from the API route.