### PR TITLE
Fix conversation layout & LLM streams

### DIFF
--- a/package/src/components/ConversationProvider.tsx
+++ b/package/src/components/ConversationProvider.tsx
@@ -29,6 +29,7 @@ export const ConversationProvider = ({ children }: React.PropsWithChildren) => {
     injectMessage,
     upsertUserTranscript,
     updateAssistantText,
+    startAssistantLlmStream,
   } = useConversationStore();
 
   const userStoppedTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -39,24 +40,7 @@ export const ConversationProvider = ({ children }: React.PropsWithChildren) => {
   });
 
   useRTVIClientEvent(RTVIEvent.BotLlmStarted, () => {
-    // Start a new assistant message only if there isn't one already in progress
-    const store = useConversationStore.getState();
-    const lastAssistantIndex = store.messages.findLastIndex(
-      (msg: ConversationMessage) => msg.role === "assistant",
-    );
-    const lastAssistant =
-      lastAssistantIndex !== -1
-        ? store.messages[lastAssistantIndex]
-        : undefined;
-
-    if (!lastAssistant || lastAssistant.final) {
-      addMessage({
-        role: "assistant",
-        final: false,
-        parts: [],
-      });
-    }
-
+    startAssistantLlmStream();
     // Nudge a reset counter so any consumer logic can infer fresh turn if needed
     assistantStreamResetRef.current += 1;
   });

--- a/package/src/components/elements/Conversation.tsx
+++ b/package/src/components/elements/Conversation.tsx
@@ -162,12 +162,7 @@ export const Conversation: React.FC<ConversationProps> = memo(
             classNames.container,
           )}
         >
-          <div
-            className={cn(
-              "grid grid-cols-[min-content_1fr] gap-x-4 gap-y-2",
-              classNames.message,
-            )}
-          >
+          <div className={cn(classNames.message)}>
             {messages.map((message, index) => (
               <MessageContainer
                 key={index}

--- a/package/src/components/elements/MessageContent.tsx
+++ b/package/src/components/elements/MessageContent.tsx
@@ -35,7 +35,7 @@ export const MessageContent = ({ classNames = {}, message }: Props) => {
   return (
     <div className={cn("flex flex-col gap-2", classNames.messageContent)}>
       {parts.map((part: ConversationMessagePart, idx: number) => {
-        const nextPart = idx < parts.length - 1 ? parts[idx + 1] : null;
+        const nextPart = parts?.[idx + 1] ?? null;
         const isText = typeof part.text === "string";
         const nextIsText = nextPart && typeof nextPart.text === "string";
         return (

--- a/package/src/templates/Console/Console.stories.tsx
+++ b/package/src/templates/Console/Console.stories.tsx
@@ -10,29 +10,39 @@ export default {
 
 export const Default = () => {
   const injectMessageRef = useRef<
-    ((message: Pick<ConversationMessage, "role" | "content">) => void) | null
+    ((message: Pick<ConversationMessage, "role" | "parts">) => void) | null
   >(null);
   const [isReady, setIsReady] = useState(false);
 
   const handleInjectUserMessage = useCallback(() => {
     injectMessageRef.current?.({
       role: "user",
-      content: "Hello! This is a test message from the user.",
+      parts: [
+        {
+          text: "Hello! This is a test message from the user.",
+          final: true,
+          createdAt: new Date().toISOString(),
+        },
+      ],
     });
   }, []);
 
   const handleInjectAssistantMessage = useCallback(() => {
     injectMessageRef.current?.({
       role: "assistant",
-      content: "Hi there! This is a test response from the assistant.",
+      parts: [
+        {
+          text: "Hi there! This is a test response from the assistant.",
+          final: true,
+          createdAt: new Date().toISOString(),
+        },
+      ],
     });
   }, []);
 
   const handleOnInjectMessage = useCallback(
     (
-      injectFn: (
-        message: Pick<ConversationMessage, "role" | "content">,
-      ) => void,
+      injectFn: (message: Pick<ConversationMessage, "role" | "parts">) => void,
     ) => {
       injectMessageRef.current = injectFn;
       setIsReady(true);


### PR DESCRIPTION
This PR fixes a few things:

- Conversation layout was broken
- Console stories were using old conversation message types
- Simplified check for next part in message rendering 
- Fixed handling of multiple succeeding bot turns: they're now broken into multiple message parts instead of concatenated into a single part.