### PR TITLE
Update UserVideoControl & add UserScreenControl

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@daily-co/daily-js": "^0.84.0",
     "@pipecat-ai/client-js": "^1.4.0",
-    "@pipecat-ai/client-react": "^1.0.1",
+    "@pipecat-ai/client-react": "^1.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tailwindcss": "^4.1.13"

--- a/package/package.json
+++ b/package/package.json
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "@daily-co/daily-js": ">=0.84.0",
     "@pipecat-ai/client-js": ">=1.4.0",
-    "@pipecat-ai/client-react": ">=1.0.1",
+    "@pipecat-ai/client-react": ">=1.1.0",
     "@pipecat-ai/daily-transport": ">=1.2.1",
     "@pipecat-ai/small-webrtc-transport": ">=1.3.0",
     "react": ">=16.8.0 || >=17.0.0 || >=18.0.0",
@@ -111,7 +111,7 @@
     "@eslint/js": "^9.36.0",
     "@ladle/react": "^5.0.3",
     "@pipecat-ai/client-js": "^1.4.0",
-    "@pipecat-ai/client-react": "^1.0.1",
+    "@pipecat-ai/client-react": "^1.1.0",
     "@pipecat-ai/daily-transport": "^1.4.0",
     "@pipecat-ai/small-webrtc-transport": "^1.5.0",
     "@tailwindcss/vite": "^4.1.13",

--- a/package/src/components/elements/UserScreenControl.tsx
+++ b/package/src/components/elements/UserScreenControl.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  type ButtonSize,
+  type ButtonState,
+  type ButtonVariant,
+} from "@/components/ui/buttonVariants";
+import { usePipecatConnectionState } from "@/hooks";
+import { cn } from "@/lib/utils";
+import {
+  type OptionalMediaDeviceInfo,
+  PipecatClientScreenShareToggle,
+  PipecatClientVideo,
+} from "@pipecat-ai/client-react";
+import { LoaderCircle, MonitorIcon, MonitorOffIcon } from "lucide-react";
+
+/**
+ * Base props interface for UserScreenControl components.
+ * Provides styling, behavior, and customization options for screen sharing controls.
+ */
+export interface UserScreenControlBaseProps {
+  /** Visual style variant for the control button */
+  variant?: ButtonVariant;
+  /** Size of the control button */
+  size?: ButtonSize;
+  /** State of the control button (default, inactive, etc.) */
+  state?: ButtonState;
+  /** Additional props to pass to the main control button */
+  buttonProps?: Partial<React.ComponentProps<typeof Button>>;
+  /** Custom CSS classes for different parts of the component */
+  classNames?: {
+    /** CSS classes for the main container */
+    container?: string;
+    /** CSS classes for the screen element */
+    screen?: string;
+    /** CSS classes for the button group */
+    buttongroup?: string;
+    /** CSS classes for the main control button */
+    button?: string;
+    /** CSS classes for the screen off state container */
+    screenOffContainer?: string;
+    /** CSS classes for the screen off state text */
+    screenOffText?: string;
+    /** CSS classes for active state text */
+    activeText?: string;
+    /** CSS classes for inactive state text */
+    inactiveText?: string;
+  };
+  /** Whether to hide the screen element entirely */
+  noScreen?: boolean;
+  /** Additional props to pass to the PipecatClientVideo component (used for screen sharing) */
+  screenProps?: Partial<React.ComponentProps<typeof PipecatClientVideo>>;
+  /** Custom text to display when screen sharing is disabled */
+  noScreenText?: string | null;
+  /** Whether to hide the screen icon in the button */
+  noIcon?: boolean;
+  /** Text to display when screen sharing is active */
+  activeText?: string;
+  /** Text to display when screen sharing is inactive */
+  inactiveText?: string;
+  /** Custom content to render inside the button */
+  children?: React.ReactNode;
+}
+
+/**
+ * Props interface for the headless UserScreenComponent.
+ * Includes device data and callbacks for external state management.
+ */
+export interface UserScreenComponentProps extends UserScreenControlBaseProps {
+  /** Callback function called when the screen toggle button is clicked */
+  onClick?: () => void;
+  /** Whether the screen sharing is currently enabled */
+  isScreenEnabled?: boolean;
+  /** Array of available screen sources */
+  availableScreens?: MediaDeviceInfo[];
+  /** Currently selected screen source */
+  selectedScreen?: OptionalMediaDeviceInfo;
+  /** Callback function called when a screen source is selected */
+  updateScreen?: (deviceId: string) => void;
+}
+
+/**
+ * Headless UserScreenComponent that accepts all device data and callbacks as props.
+ * This component can be used with any framework or state management solution.
+ *
+ * @example
+ * ```tsx
+ * <UserScreenComponent
+ *   isScreenEnabled={isScreenSharingOn}
+ *   onClick={handleScreenToggle}
+ *   availableScreens={screens}
+ *   selectedScreen={currentScreen}
+ *   updateScreen={handleScreenChange}
+ *   variant="outline"
+ *   size="lg"
+ * />
+ * ```
+ */
+export const UserScreenComponent: React.FC<UserScreenComponentProps> = ({
+  variant = "secondary",
+  size = "md",
+  classNames = {},
+  buttonProps = {},
+  noScreen = false,
+  screenProps = {},
+  isScreenEnabled = false,
+  state,
+  noScreenText = "Screen sharing disabled",
+  noIcon = false,
+  activeText,
+  inactiveText,
+  children,
+  onClick,
+}) => {
+  const buttonState = state || (isScreenEnabled ? "active" : "inactive");
+
+  // Determine button content and styling based on state
+  const getButtonContent = () => {
+    if (buttonProps?.isLoading) {
+      return (
+        <>
+          {!buttonProps?.isLoading && (
+            <>
+              {!noIcon && <MonitorOffIcon />}
+              {noScreenText && <span className="flex-1">{noScreenText}</span>}
+              {children}
+            </>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <>
+        {!noIcon && (isScreenEnabled ? <MonitorIcon /> : <MonitorOffIcon />)}
+        {!noScreen && buttonState === "inactive" && inactiveText ? (
+          <span className={cn("flex-1", classNames.inactiveText)}>
+            {inactiveText}
+          </span>
+        ) : null}
+        {!noScreen && buttonState !== "inactive" && activeText ? (
+          <span className={cn("flex-1", classNames.activeText)}>
+            {activeText}
+          </span>
+        ) : null}
+        {children}
+      </>
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative",
+        {
+          "aspect-video bg-primary rounded-md": !noScreen,
+        },
+        classNames.container,
+      )}
+    >
+      {!noScreen && (
+        <>
+          <PipecatClientVideo
+            className={cn(
+              "rounded-md w-full h-full object-cover aspect-video",
+              {
+                hidden: !isScreenEnabled,
+              },
+              classNames.screen,
+            )}
+            participant="local"
+            trackType="screenVideo"
+            {...screenProps}
+          />
+
+          {buttonProps?.isLoading && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <LoaderCircle className="animate-spin" size={24} />
+            </div>
+          )}
+        </>
+      )}
+
+      <div
+        className={cn({
+          "absolute bottom-2 left-2": !noScreen,
+        })}
+      >
+        <Button
+          className={cn(
+            {
+              "w-fit! hover:opacity-100! hover:bg-muted hover:text-muted-foreground":
+                !noScreen,
+              "flex-1 w-full z-10": noScreen,
+              "bg-active text-active-foreground": isScreenEnabled,
+            },
+            classNames.button,
+          )}
+          variant={variant}
+          size={size}
+          state={buttonState}
+          onClick={buttonProps?.isLoading ? undefined : onClick}
+          isIcon={!noScreen}
+          disabled={buttonProps?.disabled || buttonProps?.isLoading}
+          {...buttonProps}
+        >
+          {getButtonContent()}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Connected UserScreenControl component that integrates with the Pipecat Client SDK.
+ * This component automatically manages screen sharing detection, selection, and updates.
+ * Must be used within a PipecatClientProvider context.
+ *
+ * @example
+ * ```tsx
+ * <UserScreenControl
+ *   variant="outline"
+ *   size="lg"
+ *   noDevicePicker={false}
+ *   activeText="Screen sharing is on"
+ *   inactiveText="Screen sharing is off"
+ * />
+ * ```
+ */
+export const UserScreenControl: React.FC<UserScreenControlBaseProps> = (
+  props,
+) => {
+  const { isConnected } = usePipecatConnectionState();
+
+  return (
+    <PipecatClientScreenShareToggle>
+      {({ isScreenShareEnabled, onClick }) => (
+        <>
+          <UserScreenComponent
+            isScreenEnabled={isScreenShareEnabled}
+            noScreen={!isScreenShareEnabled}
+            onClick={onClick}
+            {...props}
+            buttonProps={{
+              disabled: !isConnected,
+              ...props.buttonProps,
+            }}
+          />
+        </>
+      )}
+    </PipecatClientScreenShareToggle>
+  );
+};
+export default UserScreenControl;

--- a/package/src/components/panels/InfoPanel.tsx
+++ b/package/src/components/panels/InfoPanel.tsx
@@ -32,6 +32,8 @@ export const InfoPanel: React.FC<Props> = ({
   const noDevices = noAudioOutput && noUserAudio && noUserVideo;
   const noInfoPanel = noStatusInfo && noDevices && noSessionInfo;
 
+  const { isCamEnabled } = usePipecatClientCamControl();
+
   if (noInfoPanel) return null;
 
   return (
@@ -53,7 +55,7 @@ export const InfoPanel: React.FC<Props> = ({
           </PanelHeader>
           <PanelContent>
             {!noUserAudio && <UserAudioControl />}
-            {!noUserVideo && <UserVideoControl />}
+            {!noUserVideo && <UserVideoControl noVideo={!isCamEnabled} />}
             {!noAudioOutput && <AudioOutput />}
           </PanelContent>
         </>

--- a/package/src/components/panels/InfoPanel.tsx
+++ b/package/src/components/panels/InfoPanel.tsx
@@ -2,6 +2,7 @@ import { ClientStatus } from "@/components/elements/ClientStatus";
 import { SessionInfo } from "@/components/elements/SessionInfo";
 import UserAudioControl from "@/components/elements/UserAudioControl";
 import AudioOutput from "@/components/elements/UserAudioOutputControl";
+import UserScreenControl from "@/components/elements/UserScreenControl";
 import UserVideoControl from "@/components/elements/UserVideoControl";
 import {
   Panel,
@@ -9,6 +10,7 @@ import {
   PanelHeader,
   PanelTitle,
 } from "@/components/ui/panel";
+import { usePipecatClientCamControl } from "@pipecat-ai/client-react";
 
 interface Props {
   noAudioOutput?: boolean;
@@ -16,6 +18,7 @@ interface Props {
   noStatusInfo?: boolean;
   noUserAudio?: boolean;
   noUserVideo?: boolean;
+  noScreenControl?: boolean;
   participantId?: string;
   sessionId?: string;
 }
@@ -26,10 +29,12 @@ export const InfoPanel: React.FC<Props> = ({
   noStatusInfo = false,
   noUserAudio = false,
   noUserVideo = false,
+  noScreenControl = false,
   participantId,
   sessionId,
 }) => {
-  const noDevices = noAudioOutput && noUserAudio && noUserVideo;
+  const noDevices =
+    noAudioOutput && noUserAudio && noUserVideo && noScreenControl;
   const noInfoPanel = noStatusInfo && noDevices && noSessionInfo;
 
   const { isCamEnabled } = usePipecatClientCamControl();
@@ -56,6 +61,7 @@ export const InfoPanel: React.FC<Props> = ({
           <PanelContent>
             {!noUserAudio && <UserAudioControl />}
             {!noUserVideo && <UserVideoControl noVideo={!isCamEnabled} />}
+            {!noScreenControl && <UserScreenControl />}
             {!noAudioOutput && <AudioOutput />}
           </PanelContent>
         </>

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -38,7 +38,10 @@ import { usePipecatConversation } from "@/hooks/usePipecatConversation";
 import { cn } from "@/lib/utils";
 import { type ConversationMessage } from "@/types/conversation";
 import { type PipecatClientOptions, RTVIEvent } from "@pipecat-ai/client-js";
-import { useRTVIClientEvent } from "@pipecat-ai/client-react";
+import {
+  usePipecatClientCamControl,
+  useRTVIClientEvent,
+} from "@pipecat-ai/client-react";
 import {
   BotIcon,
   ChevronsLeftRightEllipsisIcon,
@@ -269,6 +272,7 @@ const ConsoleUI = ({
   const infoPanelRef = useRef<ImperativePanelHandle>(null);
 
   const { injectMessage } = usePipecatConversation();
+  const { isCamEnabled } = usePipecatClientCamControl();
 
   // Expose injectMessage to parent if requested
   useEffect(() => {
@@ -451,7 +455,9 @@ const ConsoleUI = ({
                               side="left"
                             >
                               {!noUserAudio && <UserAudioControl />}
-                              {!noUserVideo && <UserVideoControl />}
+                              {!noUserVideo && (
+                                <UserVideoControl noVideo={!isCamEnabled} />
+                              )}
                               {!noAudioOutput && <UserAudioOutputControl />}
                             </PopoverContent>
                           </Popover>

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -56,6 +56,7 @@ import { type ImperativePanelHandle } from "react-resizable-panels";
 import React, { memo, useEffect, useRef, useState } from "react";
 import { AutoInitDevices } from "./AutoInitDevices";
 import { SmallWebRTCCodecSetter } from "./SmallWebRTCCodecSetter";
+import UserScreenControl from "../../components/elements/UserScreenControl";
 
 export interface ConsoleTemplateProps
   extends Omit<PipecatBaseProps, "children"> {
@@ -67,6 +68,8 @@ export interface ConsoleTemplateProps
   noUserAudio?: boolean;
   /** Disables user video input entirely. Default: false */
   noUserVideo?: boolean;
+  /** Disables user screen control entirely. Default: false */
+  noScreenControl?: boolean;
   /** Disables audio output for the bot. Default: false */
   noAudioOutput?: boolean;
   /** Disables audio visualization for the bot. Default: false */
@@ -224,6 +227,7 @@ const ConsoleUI = ({
   // serverRTVIVersion,
   noUserAudio = false,
   noUserVideo = false,
+  noScreenControl = false,
   noAudioOutput = false,
   noBotAudio = false,
   noBotVideo = false,
@@ -281,7 +285,8 @@ const ConsoleUI = ({
 
   const noBotArea = noBotAudio && noBotVideo;
   const noConversationPanel = noConversation && noMetrics;
-  const noDevices = noAudioOutput && noUserAudio && noUserVideo;
+  const noDevices =
+    noAudioOutput && noUserAudio && noUserVideo && noScreenControl;
   const noInfoPanel = noStatusInfo && noDevices && noSessionInfo;
 
   useRTVIClientEvent(RTVIEvent.ParticipantConnected, (p) => {
@@ -458,6 +463,7 @@ const ConsoleUI = ({
                               {!noUserVideo && (
                                 <UserVideoControl noVideo={!isCamEnabled} />
                               )}
+                              {!noScreenControl && <UserScreenControl />}
                               {!noAudioOutput && <UserAudioOutputControl />}
                             </PopoverContent>
                           </Popover>
@@ -485,6 +491,7 @@ const ConsoleUI = ({
                         noStatusInfo={noStatusInfo}
                         noUserAudio={noUserAudio}
                         noUserVideo={noUserVideo}
+                        noScreenControl={noScreenControl}
                         participantId={participantId}
                         sessionId={sessionId}
                       />
@@ -537,6 +544,7 @@ const ConsoleUI = ({
                 noAudioOutput={noAudioOutput}
                 noUserAudio={noUserAudio}
                 noUserVideo={noUserVideo}
+                noScreenControl={noScreenControl}
                 participantId={participantId}
                 sessionId={sessionId}
               />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@pipecat-ai/client-react':
-        specifier: ^1.0.1
-        version: 1.0.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@pipecat-ai/client-js@1.4.0)(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: ^1.1.0
+        version: 1.1.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@pipecat-ai/client-js@1.4.0)(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -419,8 +419,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@pipecat-ai/client-react':
-        specifier: ^1.0.1
-        version: 1.0.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@pipecat-ai/client-js@1.4.0)(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: ^1.1.0
+        version: 1.1.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@pipecat-ai/client-js@1.4.0)(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@pipecat-ai/daily-transport':
         specifier: ^1.4.0
         version: 1.4.0(@pipecat-ai/client-js@1.4.0)
@@ -1453,8 +1453,8 @@ packages:
   '@pipecat-ai/client-js@1.4.0':
     resolution: {integrity: sha512-HOWz4OWXbIetkywwrfVuEiEpU8FVFksmyP/rSWHSQGu/V2MJflAXfFt2tQmtu8RiQCA7C1qurfZGsxeccYmJXw==}
 
-  '@pipecat-ai/client-react@1.0.1':
-    resolution: {integrity: sha512-ziW7OnBB/FGN/TLHB00KJcVU+6HToS82CSpJJrqm9dBP54hFxQ/iTjkmTnDyMRftv57HTPqbw4klqhjvJDLANQ==}
+  '@pipecat-ai/client-react@1.1.0':
+    resolution: {integrity: sha512-OfXd2vd8ooOE1I/7SwVnSPXz2UC/L2GlAMYVO40ClzoeeJidywcNfbqTO2ZDxcxvFf15tv4O9aAM3uPo4Ou13A==}
     peerDependencies:
       '@pipecat-ai/client-js': '*'
       react: '>=18'
@@ -6954,7 +6954,7 @@ snapshots:
       typed-emitter: 2.1.0
       uuid: 10.0.0
 
-  '@pipecat-ai/client-react@1.0.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@pipecat-ai/client-js@1.4.0)(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@pipecat-ai/client-react@1.1.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@pipecat-ai/client-js@1.4.0)(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@pipecat-ai/client-js': 1.4.0
       jotai: 2.15.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.16)(react@19.1.1)


### PR DESCRIPTION
This PR updates `UserVideoControl` to visually match `UserAudioControl`, updates the `@pipecat-ai/client-react` dependency to 1.1.0 and adds a new `UserScreenControl` component.

The screen share control is only enabled when fully connected, otherwise the client seems to throw or log an error.

<img width="596" height="352" alt="CleanShot 2025-10-08 at 17 42 19@2x" src="https://github.com/user-attachments/assets/1006c590-47c3-4990-ac74-08c4bc8bc237" />
