### PR TITLE
feat(conversation): add textRenderMode switch for bot message display

### DIFF
--- a/docs/content/docs/components/Conversation.mdx
+++ b/docs/content/docs/components/Conversation.mdx
@@ -95,6 +95,12 @@ The Conversation component displays real-time conversation history between users
       required: false,
       default: "false",
     },
+    textRenderMode: {
+      description: 'Controls how bot message text is rendered. "karaoke": full text with the already-spoken portion normal and the upcoming portion muted. "captions": show only the portion that has been spoken (synced to audio). "instant": show the full LLM text immediately, no highlighting.',
+      type: '"karaoke" | "captions" | "instant"',
+      required: false,
+      default: '"karaoke"',
+    },
   }}
 />
 

--- a/docs/content/docs/panels/ConversationPanel.mdx
+++ b/docs/content/docs/panels/ConversationPanel.mdx
@@ -51,6 +51,18 @@ The ConversationPanel component provides a tabbed interface combining conversati
       required: false,
       default: "false",
     },
+    textRenderMode: {
+      description: 'Initial text render mode for bot messages. "karaoke": full text with the already-spoken portion normal and the upcoming portion muted. "captions": show only the portion that has been spoken (synced to audio). "instant": show the full LLM text immediately, no highlighting. The panel header also renders a switch so end users can change this at runtime.',
+      type: '"karaoke" | "captions" | "instant"',
+      required: false,
+      default: '"karaoke"',
+    },
+    noTextRenderModeSwitch: {
+      description: "Hide the text render mode switch in the panel header.",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
   }}
 />
 

--- a/docs/content/docs/templates/console.mdx
+++ b/docs/content/docs/templates/console.mdx
@@ -271,6 +271,18 @@ The ConsoleTemplate extends `PipecatBaseProps` and adds additional configuration
       required: false,
       default: "false",
     },
+    textRenderMode: {
+      description: 'Initial text render mode for bot messages in the conversation panel. "karaoke": full text with the already-spoken portion normal and the upcoming portion muted. "captions": show only the portion that has been spoken (synced to audio). "instant": show the full LLM text immediately, no highlighting. Users can flip between modes at runtime via the switch in the conversation panel header.',
+      type: '"karaoke" | "captions" | "instant"',
+      required: false,
+      default: '"karaoke"',
+    },
+    noTextRenderModeSwitch: {
+      description: "Hide the text render mode switch in the conversation panel header.",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
     logoComponent: {
       description: "Custom logo component to display in the header",
       type: "React.ReactNode",

--- a/package/src/components/elements/Conversation.tsx
+++ b/package/src/components/elements/Conversation.tsx
@@ -1,5 +1,6 @@
 import { usePipecatConversation } from "@/hooks/usePipecatConversation";
 import { cn } from "@/lib/utils";
+import type { TextRenderMode } from "@/types/conversation";
 import { usePipecatClientTransportState } from "@pipecat-ai/client-react";
 import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { MessageContainer } from "./MessageContainer";
@@ -106,6 +107,14 @@ export interface ConversationProps {
   aggregationMetadata?: React.ComponentProps<
     typeof MessageContainer
   >["aggregationMetadata"];
+  /**
+   * Controls how bot message text is rendered.
+   * - "karaoke": Spoken text normal, unspoken text muted (default)
+   * - "spoken": Show only the spoken portion
+   * - "unspoken": Show full LLM text without highlighting
+   * @default "karaoke"
+   */
+  textRenderMode?: TextRenderMode;
 }
 
 /**
@@ -150,6 +159,7 @@ export const Conversation: React.FC<ConversationProps> = memo(
     functionCallRenderer,
     botOutputRenderers,
     aggregationMetadata,
+    textRenderMode,
   }) => {
     const transportState = usePipecatClientTransportState();
 
@@ -188,8 +198,15 @@ export const Conversation: React.FC<ConversationProps> = memo(
       }
     }, [noAutoscroll, reverseOrder]);
 
+    // Map textRenderMode to botOutputFilter
+    const botOutputFilter = useMemo(() => {
+      if (textRenderMode === "spoken") return { unspoken: false };
+      return undefined; // "karaoke" and "unspoken" both need all data
+    }, [textRenderMode]);
+
     const { messages: allMessages } = usePipecatConversation({
       aggregationMetadata,
+      botOutputFilter,
     });
     const { botOutputSupported } = useConversationContext();
 
@@ -298,6 +315,7 @@ export const Conversation: React.FC<ConversationProps> = memo(
                     classNames={messageClassNames}
                     botOutputRenderers={botOutputRenderers}
                     aggregationMetadata={aggregationMetadata}
+                    textRenderMode={textRenderMode}
                   />
                 ),
               )}

--- a/package/src/components/elements/Conversation.tsx
+++ b/package/src/components/elements/Conversation.tsx
@@ -109,9 +109,9 @@ export interface ConversationProps {
   >["aggregationMetadata"];
   /**
    * Controls how bot message text is rendered.
-   * - "karaoke": Spoken text normal, unspoken text muted (default)
-   * - "spoken": Show only the spoken portion
-   * - "unspoken": Show full LLM text without highlighting
+   * - "karaoke": Full text, already-spoken portion normal, upcoming portion muted (default)
+   * - "captions": Show only the portion that has been spoken (synced to audio)
+   * - "instant": Show the full LLM text immediately, no highlighting
    * @default "karaoke"
    */
   textRenderMode?: TextRenderMode;
@@ -200,8 +200,8 @@ export const Conversation: React.FC<ConversationProps> = memo(
 
     // Map textRenderMode to botOutputFilter
     const botOutputFilter = useMemo(() => {
-      if (textRenderMode === "spoken") return { unspoken: false };
-      return undefined; // "karaoke" and "unspoken" both need all data
+      if (textRenderMode === "captions") return { unspoken: false };
+      return undefined; // "karaoke" and "instant" both need all data
     }, [textRenderMode]);
 
     const { messages: allMessages } = usePipecatConversation({

--- a/package/src/components/elements/MessageContainer.tsx
+++ b/package/src/components/elements/MessageContainer.tsx
@@ -4,6 +4,7 @@ import type {
   AggregationMetadata,
   ConversationMessage,
   FunctionCallRenderer,
+  TextRenderMode,
 } from "@/types/conversation";
 import { MessageRole } from "./MessageRole";
 import { MessageContent } from "./MessageContent";
@@ -80,6 +81,11 @@ interface Props {
    * Metadata for aggregation types to control rendering and speech progress behavior
    */
   aggregationMetadata?: Record<string, AggregationMetadata>;
+  /**
+   * Controls how bot message text is rendered.
+   * @default "karaoke"
+   */
+  textRenderMode?: TextRenderMode;
 }
 
 export const MessageContainer = memo(
@@ -93,6 +99,7 @@ export const MessageContainer = memo(
     message,
     botOutputRenderers,
     aggregationMetadata,
+    textRenderMode,
   }: Props) => {
     if (message.role === "function_call" && message.functionCall) {
       return (
@@ -133,6 +140,7 @@ export const MessageContainer = memo(
           message={message}
           botOutputRenderers={botOutputRenderers}
           aggregationMetadata={aggregationMetadata}
+          textRenderMode={textRenderMode}
         />
       </div>
     );

--- a/package/src/components/elements/MessageContent.tsx
+++ b/package/src/components/elements/MessageContent.tsx
@@ -5,6 +5,7 @@ import {
   BotOutputText,
   ConversationMessage,
   ConversationMessagePart,
+  TextRenderMode,
 } from "@/types/conversation";
 import { Fragment } from "react";
 import Thinking from "./Thinking";
@@ -52,6 +53,11 @@ interface Props {
    * Key is the aggregation type (e.g., "code", "link"), value is metadata configuration
    */
   aggregationMetadata?: Record<string, AggregationMetadata>;
+  /**
+   * Controls how bot message text is rendered.
+   * @default "karaoke"
+   */
+  textRenderMode?: TextRenderMode;
 }
 
 /**
@@ -69,6 +75,7 @@ const renderBotOutput = (
   aggregatedBy?: string,
   customRenderer?: CustomBotOutputRenderer,
   metadata?: AggregationMetadata,
+  textRenderMode?: TextRenderMode,
 ): React.ReactNode => {
   // Use custom renderer if provided and aggregation type matches
   if (aggregatedBy && customRenderer) {
@@ -79,6 +86,16 @@ const renderBotOutput = (
   // Default rendering - unspoken is already split at the correct position
   const displayMode = metadata?.displayMode || "inline";
   const Wrapper = displayMode === "block" ? "div" : "span";
+
+  // In "unspoken" mode, render all text in normal color (no karaoke highlighting)
+  if (textRenderMode === "unspoken") {
+    return (
+      <Wrapper>
+        {spoken}
+        {unspoken}
+      </Wrapper>
+    );
+  }
 
   return (
     <Wrapper>
@@ -104,6 +121,7 @@ const renderPartContent = (
   part: ConversationMessagePart,
   botOutputRenderers?: Record<string, CustomBotOutputRenderer>,
   aggregationMetadata?: Record<string, AggregationMetadata>,
+  textRenderMode?: TextRenderMode,
 ): React.ReactNode => {
   if (!part.text) return null;
   if (isBotOutputText(part)) {
@@ -120,6 +138,7 @@ const renderPartContent = (
       part.aggregatedBy,
       customRenderer,
       metadata,
+      textRenderMode,
     );
   }
   return part.text as React.ReactNode;
@@ -130,6 +149,7 @@ export const MessageContent = ({
   aggregationMetadata,
   classNames = {},
   message,
+  textRenderMode,
 }: Props) => {
   const parts = Array.isArray(message.parts) ? message.parts : [];
 
@@ -178,6 +198,7 @@ export const MessageContent = ({
                   part,
                   botOutputRenderers,
                   aggregationMetadata,
+                  textRenderMode,
                 );
                 const shouldAddSpace = partIdx > 0 && !isBotOutputText(part);
 
@@ -200,6 +221,7 @@ export const MessageContent = ({
                     part,
                     botOutputRenderers,
                     aggregationMetadata,
+                    textRenderMode,
                   )}
                 </Fragment>
               ))}

--- a/package/src/components/elements/MessageContent.tsx
+++ b/package/src/components/elements/MessageContent.tsx
@@ -87,8 +87,8 @@ const renderBotOutput = (
   const displayMode = metadata?.displayMode || "inline";
   const Wrapper = displayMode === "block" ? "div" : "span";
 
-  // In "unspoken" mode, render all text in normal color (no karaoke highlighting)
-  if (textRenderMode === "unspoken") {
+  // In "instant" mode, render all text in normal color (no karaoke highlighting)
+  if (textRenderMode === "instant") {
     return (
       <Wrapper>
         {spoken}

--- a/package/src/components/panels/ConversationPanel.tsx
+++ b/package/src/components/panels/ConversationPanel.tsx
@@ -107,8 +107,8 @@ export const ConversationPanel: React.FC<ConversationPanelProps> = memo(
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="karaoke">Karaoke</SelectItem>
-                  <SelectItem value="spoken">Spoken</SelectItem>
-                  <SelectItem value="unspoken">Unspoken</SelectItem>
+                  <SelectItem value="captions">Captions</SelectItem>
+                  <SelectItem value="instant">Instant</SelectItem>
                 </SelectContent>
               </Select>
             )}

--- a/package/src/components/panels/ConversationPanel.tsx
+++ b/package/src/components/panels/ConversationPanel.tsx
@@ -2,9 +2,17 @@ import type { ConversationProps } from "@/components/elements/Conversation";
 import Conversation from "@/components/elements/Conversation";
 import { Metrics } from "@/components/metrics";
 import { Panel, PanelContent, PanelHeader } from "@/components/ui/panel";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { TextRenderMode } from "@/types/conversation";
 import { LineChartIcon, MessagesSquareIcon } from "lucide-react";
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 
 interface ConversationPanelProps {
   /**
@@ -32,6 +40,16 @@ interface ConversationPanelProps {
    * @default false
    */
   noFunctionCalls?: boolean;
+  /**
+   * Text rendering mode for bot messages.
+   * @default "karaoke"
+   */
+  textRenderMode?: TextRenderMode;
+  /**
+   * Hides the text render mode switch in the panel header.
+   * @default false
+   */
+  noTextRenderModeSwitch?: boolean;
 }
 
 export const ConversationPanel: React.FC<ConversationPanelProps> = memo(
@@ -41,7 +59,18 @@ export const ConversationPanel: React.FC<ConversationPanelProps> = memo(
     noMetrics = false,
     noTextInput = false,
     noFunctionCalls = false,
+    textRenderMode,
+    noTextRenderModeSwitch = false,
   }) => {
+    const [localTextRenderMode, setLocalTextRenderMode] =
+      useState<TextRenderMode>(textRenderMode ?? "karaoke");
+
+    useEffect(() => {
+      if (textRenderMode !== undefined) {
+        setLocalTextRenderMode(textRenderMode);
+      }
+    }, [textRenderMode]);
+
     const defaultValue = noConversation ? "metrics" : "conversation";
 
     return (
@@ -62,6 +91,27 @@ export const ConversationPanel: React.FC<ConversationPanelProps> = memo(
                 </TabsTrigger>
               )}
             </TabsList>
+            {!noTextRenderModeSwitch && (
+              <Select
+                value={localTextRenderMode}
+                onValueChange={(v) =>
+                  setLocalTextRenderMode(v as TextRenderMode)
+                }
+              >
+                <SelectTrigger
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto w-auto gap-1"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="karaoke">Karaoke</SelectItem>
+                  <SelectItem value="spoken">Spoken</SelectItem>
+                  <SelectItem value="unspoken">Unspoken</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
           </PanelHeader>
           <PanelContent className="p-0! overflow-hidden h-full">
             {!noConversation && (
@@ -80,6 +130,7 @@ export const ConversationPanel: React.FC<ConversationPanelProps> = memo(
                   botOutputRenderers={
                     conversationElementProps?.botOutputRenderers
                   }
+                  textRenderMode={localTextRenderMode}
                 />
               </TabsContent>
             )}

--- a/package/src/hooks/usePipecatConversation.ts
+++ b/package/src/hooks/usePipecatConversation.ts
@@ -21,6 +21,16 @@ interface Props {
    * Used to determine which aggregations should be excluded from position-based splitting.
    */
   aggregationMetadata?: Record<string, AggregationMetadata>;
+  /**
+   * Filter controlling which portions of BotOutput text are returned.
+   * The store always holds the full data; this filter controls what the consumer receives.
+   */
+  botOutputFilter?: {
+    /** Include spoken text (TTS-confirmed portion). Default: true */
+    spoken?: boolean;
+    /** Include unspoken text (LLM output not yet spoken). Default: true */
+    unspoken?: boolean;
+  };
 }
 
 /**
@@ -44,6 +54,7 @@ interface Props {
 export const usePipecatConversation = ({
   onMessageAdded,
   aggregationMetadata,
+  botOutputFilter,
 }: Props = {}) => {
   const { injectMessage } = useConversationContext();
   const registerMessageCallback = useConversationStore(
@@ -128,10 +139,14 @@ export const usePipecatConversation = ({
                 ? part.text.trim()
                 : part.text;
             if (!isSpoken) {
+              // Non-spoken aggregation types follow the unspoken filter
+              const includeUnspoken = botOutputFilter?.unspoken !== false;
               return {
                 ...part,
                 displayMode,
-                text: { spoken: "", unspoken: partText },
+                text: includeUnspoken
+                  ? { spoken: "", unspoken: partText }
+                  : { spoken: "", unspoken: "" },
               };
             }
 
@@ -150,10 +165,16 @@ export const usePipecatConversation = ({
                 ? ""
                 : partText;
 
+            // Apply filter
+            const filteredSpoken =
+              botOutputFilter?.spoken !== false ? spokenText : "";
+            const filteredUnspoken =
+              botOutputFilter?.unspoken !== false ? unspokenText : "";
+
             return {
               ...part,
               displayMode,
-              text: { spoken: spokenText, unspoken: unspokenText },
+              text: { spoken: filteredSpoken, unspoken: filteredUnspoken },
             };
           },
         );
@@ -167,7 +188,7 @@ export const usePipecatConversation = ({
     });
 
     return processedMessages;
-  }, [messages, botOutputMessageState, aggregationMetadata]);
+  }, [messages, botOutputMessageState, aggregationMetadata, botOutputFilter]);
 
   const botOutputEvents = useConversationStore(
     (state) => state.botOutputEvents,

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -149,9 +149,9 @@ export interface ConsoleTemplateProps
 
   /**
    * Text rendering mode for bot messages.
-   * - "karaoke": Spoken text normal, unspoken text muted (default)
-   * - "spoken": Show only the spoken portion
-   * - "unspoken": Show full LLM text without highlighting
+   * - "karaoke": Full text, already-spoken portion normal, upcoming portion muted (default)
+   * - "captions": Show only the portion that has been spoken (synced to audio)
+   * - "instant": Show the full LLM text immediately, no highlighting
    * @default "karaoke"
    */
   textRenderMode?: TextRenderMode;

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -40,7 +40,10 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { usePipecatConversation } from "@/hooks/usePipecatConversation";
 import { cn } from "@/lib/utils";
-import { type ConversationMessage } from "@/types/conversation";
+import {
+  type ConversationMessage,
+  type TextRenderMode,
+} from "@/types/conversation";
 import {
   type APIRequest,
   type PipecatClientOptions,
@@ -143,6 +146,21 @@ export interface ConsoleTemplateProps
    * The bot may still send metrics, but they won't be displayed.
    */
   noMetrics?: boolean;
+
+  /**
+   * Text rendering mode for bot messages.
+   * - "karaoke": Spoken text normal, unspoken text muted (default)
+   * - "spoken": Show only the spoken portion
+   * - "unspoken": Show full LLM text without highlighting
+   * @default "karaoke"
+   */
+  textRenderMode?: TextRenderMode;
+
+  /**
+   * Hides the text render mode switch in the conversation panel header.
+   * @default false
+   */
+  noTextRenderModeSwitch?: boolean;
 
   /**
    * Custom logo component to display in the header.
@@ -325,6 +343,8 @@ const ConsoleUI = ({
   videoCodec = "default",
   noConversation = false,
   noMetrics = false,
+  textRenderMode,
+  noTextRenderModeSwitch = false,
   logoComponent,
   conversationElementProps,
   onInjectMessage,
@@ -497,6 +517,8 @@ const ConsoleUI = ({
                         noConversation={noConversation}
                         noMetrics={noMetrics}
                         noTextInput={noTextInput}
+                        textRenderMode={textRenderMode}
+                        noTextRenderModeSwitch={noTextRenderModeSwitch}
                         conversationElementProps={{
                           ...conversationElementProps,
                           assistantLabel: assistantLabelText,
@@ -625,6 +647,8 @@ const ConsoleUI = ({
                   noConversation={noConversation}
                   noMetrics={noMetrics}
                   noTextInput={noTextInput}
+                  textRenderMode={textRenderMode}
+                  noTextRenderModeSwitch={noTextRenderModeSwitch}
                 />
               </TabsContent>
             )}

--- a/package/src/types/conversation.ts
+++ b/package/src/types/conversation.ts
@@ -78,6 +78,9 @@ export interface ConversationMessagePart {
   displayMode?: "inline" | "block";
 }
 
+/** Controls how bot message text is rendered in the UI */
+export type TextRenderMode = "karaoke" | "spoken" | "unspoken";
+
 /**
  * A raw BotOutput event stored for debugging and replay.
  * Each event represents a single BotOutput RTVI event as received.

--- a/package/src/types/conversation.ts
+++ b/package/src/types/conversation.ts
@@ -79,7 +79,7 @@ export interface ConversationMessagePart {
 }
 
 /** Controls how bot message text is rendered in the UI */
-export type TextRenderMode = "karaoke" | "spoken" | "unspoken";
+export type TextRenderMode = "karaoke" | "captions" | "instant";
 
 /**
  * A raw BotOutput event stored for debugging and replay.


### PR DESCRIPTION
> Stacked on [#103](https://github.com/pipecat-ai/voice-ui-kit/pull/103) in spirit: once that migration lands, the local `usePipecatConversation` plumbing in this PR becomes redundant (the upstream hook already exposes `botOutputFilter`). The UI layer (prop, select, mapping, `MessageContent` branch) still belongs here.

## Summary

- Adds a `textRenderMode` prop on `Conversation`, `ConversationPanel`, and `ConsoleTemplate` with three options:
  - **`"karaoke"`** (default): full text, with the already-spoken portion normal and the upcoming portion muted.
  - **`"captions"`**: show only the portion that has been spoken (synced to audio).
  - **`"instant"`**: show the full LLM text immediately, no highlighting (useful when you want to read ahead of what the bot has said).
- `ConversationPanel` renders a small `<Select>` in its header so end users can flip between modes at runtime. Hide it via `noTextRenderModeSwitch`.

## Naming note

The original draft used `"spoken"` / `"unspoken"`, which matched the internal `BotOutputText` field names but did not describe the user-visible behavior. Renamed on review (thanks @markbackman) to match the rendering semantics instead.

## Implementation

- `usePipecatConversation` gains a `botOutputFilter` option that controls which portion of each `BotOutputText` (`spoken` / `unspoken`) it returns. The store still holds the full data; only the hook's output is filtered. (This duplicates the upstream hook's filter from `@pipecat-ai/client-react` and will be deleted when [#103](https://github.com/pipecat-ai/voice-ui-kit/pull/103) lands.)
- `Conversation` maps the requested `textRenderMode` onto that filter (only `"captions"` sets `unspoken: false` — `"karaoke"` and `"instant"` both need the full data; they differ in how `MessageContent` renders it).
- `MessageContent` short-circuits the karaoke `<mark>` markup when the mode is `"instant"` so the whole text renders in a single style.
- `ConsoleTemplate` forwards `textRenderMode` + `noTextRenderModeSwitch` into `ConversationPanel`.

## Docs

- `textRenderMode` and `noTextRenderModeSwitch` documented on the [Conversation](https://github.com/pipecat-ai/voice-ui-kit/blob/cst/text-render-mode-switch/docs/content/docs/components/Conversation.mdx), [ConversationPanel](https://github.com/pipecat-ai/voice-ui-kit/blob/cst/text-render-mode-switch/docs/content/docs/panels/ConversationPanel.mdx), and [Console template](https://github.com/pipecat-ai/voice-ui-kit/blob/cst/text-render-mode-switch/docs/content/docs/templates/console.mdx) pages.

## Test plan

- [x] `pnpm --filter voice-ui-kit test -- --run` — 173 existing tests pass; no behavior change in the default `"karaoke"` path. No new tests: the kit-side logic is two one-line branches (prop → filter, prop → render branch); the filter itself is covered upstream in `@pipecat-ai/client-react`, and the repo has no component-level test infra.
- [ ] Manually exercise the panel switcher: karaoke → captions (watch trailing unspoken disappear mid-utterance), karaoke → instant (full text visible immediately, no highlight sweep), captions → karaoke, etc.
- [ ] Confirm `noTextRenderModeSwitch` hides the header control.