### PR TITLE
feat(audio): add bot audio output volume control

### DIFF
--- a/docs/content/docs/components/BotAudioControl.mdx
+++ b/docs/content/docs/components/BotAudioControl.mdx
@@ -1,0 +1,239 @@
+---
+title: Bot Audio Control
+description: Control for adjusting the bot's audio output volume
+component: BotAudioControl
+---
+
+The `BotAudioControl` component provides a button with a popover-mounted volume slider for controlling the bot's audio output level. It integrates with the kit's bot audio store so any number of instances stay in sync, and it drives the `<audio>` element rendered by `BotAudioOutput` (used automatically by `PipecatAppBase`).
+
+<LiveComponent language="tsx" withPipecat>
+{`
+  import { BotAudioControl } from "@pipecat-ai/voice-ui-kit";
+
+  <BotAudioControl />
+`}
+</LiveComponent>
+
+---
+
+<Callout>
+Mute is intentionally not provided as its own control yet. For now, sliding volume to `0` silences the bot locally. A dedicated mute affordance is being designed separately because it requires a decision about whether muting should also pause the user's microphone (to avoid the bot's LLM receiving user speech that references something the user never actually heard).
+</Callout>
+
+<TypeTable
+  className="text-sm"
+  type={{
+    variant: {
+      description: "Visual style variant of the button",
+      type: '"primary" | "secondary" | "outline" | "destructive" | "ghost" | "link" | "active" | "inactive"',
+      required: false,
+      default: '"secondary"',
+    },
+    size: {
+      description: "Size of the button component",
+      type: '"sm" | "md" | "lg" | "xl"',
+      required: false,
+      default: '"md"',
+    },
+    state: {
+      description: "Button state for visual feedback",
+      type: '"default" | "active" | "inactive"',
+      required: false,
+      default: "undefined",
+    },
+    buttonProps: {
+      description: "Props to pass to the trigger button",
+      type: "Partial<ButtonProps>",
+      required: false,
+      default: "undefined",
+    },
+    popoverProps: {
+      description: "Props forwarded to the Radix Popover root (e.g. open, defaultOpen, onOpenChange, modal)",
+      type: "Partial<React.ComponentProps<typeof Popover>>",
+      required: false,
+      default: "undefined",
+    },
+    popoverContentProps: {
+      description: "Props forwarded to PopoverContent. Use to adjust placement — align, side, sideOffset, alignOffset, collisionPadding, etc.",
+      type: "Partial<React.ComponentProps<typeof PopoverContent>>",
+      required: false,
+      default: '{ align: "center" }',
+    },
+    volumeSliderProps: {
+      description: "Props forwarded to the inner BotVolumeSliderComponent (noLabel, noPercent, orientation, sliderProps, etc.)",
+      type: "Partial<Omit<BotVolumeSliderComponentProps, 'volume' | 'onVolumeChange'>>",
+      required: false,
+      default: "undefined",
+    },
+    classNames: {
+      description: "Custom CSS classes for different parts of the component",
+      type: "{ button?: string; popoverContent?: string; slider?: string; }",
+      required: false,
+      default: "undefined",
+    },
+    noIcon: {
+      description: "Hide the volume icon in the trigger button",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
+    label: {
+      description: "Optional visible label rendered next to the icon",
+      type: "string",
+      required: false,
+      default: "undefined",
+    },
+    children: {
+      description: "Additional content to render inside the button",
+      type: "React.ReactNode",
+      required: false,
+      default: "undefined",
+    },
+  }}
+/>
+
+### BotAudioComponent
+
+The `BotAudioComponent` is the headless variant. It accepts `volume` and `onVolumeChange` directly, so you can drive it from any state source (tests, custom stores, etc.).
+
+<LiveComponent language="tsx" noInline>
+{`
+  import { BotAudioComponent } from "@pipecat-ai/voice-ui-kit";
+
+  function Demo() {
+    const [volume, setVolume] = React.useState(0.8);
+    return (
+      <BotAudioComponent
+        volume={volume}
+        onVolumeChange={setVolume}
+      />
+    );
+  }
+
+  render(<Demo />);
+`}
+</LiveComponent>
+
+<TypeTable
+  className="text-sm"
+  type={{
+    volume: {
+      description: "Current volume, in the range 0.0 – 1.0",
+      type: "number",
+      required: false,
+      default: "1",
+    },
+    onVolumeChange: {
+      description: "Callback fired when the user changes the volume. Receives a value in the range 0.0 – 1.0",
+      type: "(volume: number) => void",
+      required: false,
+      default: "undefined",
+    },
+    variant: {
+      description: "Visual style variant of the button",
+      type: '"primary" | "secondary" | "outline" | "destructive" | "ghost" | "link" | "active" | "inactive"',
+      required: false,
+      default: '"secondary"',
+    },
+    size: {
+      description: "Size of the button component",
+      type: '"sm" | "md" | "lg" | "xl"',
+      required: false,
+      default: '"md"',
+    },
+    state: {
+      description: "Button state for visual feedback",
+      type: '"default" | "active" | "inactive"',
+      required: false,
+      default: "undefined",
+    },
+    buttonProps: {
+      description: "Props to pass to the trigger button",
+      type: "Partial<ButtonProps>",
+      required: false,
+      default: "undefined",
+    },
+    popoverProps: {
+      description: "Props forwarded to the Radix Popover root (e.g. open, defaultOpen, onOpenChange, modal)",
+      type: "Partial<React.ComponentProps<typeof Popover>>",
+      required: false,
+      default: "undefined",
+    },
+    popoverContentProps: {
+      description: "Props forwarded to PopoverContent. Use to adjust placement — align, side, sideOffset, alignOffset, collisionPadding, etc.",
+      type: "Partial<React.ComponentProps<typeof PopoverContent>>",
+      required: false,
+      default: '{ align: "center" }',
+    },
+    volumeSliderProps: {
+      description: "Props forwarded to the inner BotVolumeSliderComponent (noLabel, noPercent, orientation, sliderProps, etc.)",
+      type: "Partial<Omit<BotVolumeSliderComponentProps, 'volume' | 'onVolumeChange'>>",
+      required: false,
+      default: "undefined",
+    },
+    classNames: {
+      description: "Custom CSS classes for different parts of the component",
+      type: "{ button?: string; popoverContent?: string; slider?: string; }",
+      required: false,
+      default: "undefined",
+    },
+    noIcon: {
+      description: "Hide the volume icon in the trigger button",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
+    label: {
+      description: "Optional visible label rendered next to the icon",
+      type: "string",
+      required: false,
+      default: "undefined",
+    },
+    children: {
+      description: "Additional content to render inside the button",
+      type: "React.ReactNode",
+      required: false,
+      default: "undefined",
+    },
+  }}
+/>
+
+---
+
+## Adjusting placement
+
+Pass `popoverContentProps` to override placement defaults:
+
+```tsx
+<BotAudioControl
+  popoverContentProps={{
+    align: "end",
+    side: "bottom",
+    sideOffset: 8,
+  }}
+/>
+```
+
+Pass `popoverProps` to control open state (e.g. for a controlled popover):
+
+```tsx
+<BotAudioControl
+  popoverProps={{ open, onOpenChange: setOpen }}
+/>
+```
+
+## Integration
+
+The connected `BotAudioControl` reads and writes volume through the [`useBotAudioOutput`](/hooks/useBotAudioOutput) hook, and uses `usePipecatClientTransportState` to disable the control while the transport is disconnected or initializing. It must be used within a `PipecatClientProvider` context (typically provided by `PipecatAppBase`).
+
+Volume is applied to the `<audio>` element rendered by `BotAudioOutput`, which `PipecatAppBase` mounts in place of `PipecatClientAudio` unless `noAudioOutput` is `true`.
+
+## Visual States
+
+The icon inside the trigger button reflects the current volume level (muted, low, medium, high). This is purely cosmetic and does not represent a separate mute state.
+
+## Also see
+
+- [`BotVolumeSlider`](/components/BotVolumeSlider) — the inline slider rendered inside this control's popover, usable standalone.
+- [`useBotAudioOutput`](/hooks/useBotAudioOutput) for reading or driving the bot volume from anywhere in your app.
+- [`BotAudioPanel`](/panels/BotAudioPanel) — renders a `BotAudioControl` in its header by default; pass `noControls` to hide it.

--- a/docs/content/docs/components/BotAudioControl.mdx
+++ b/docs/content/docs/components/BotAudioControl.mdx
@@ -57,7 +57,7 @@ Mute is intentionally not provided as its own control yet. For now, sliding volu
       description: "Props forwarded to PopoverContent. Use to adjust placement — align, side, sideOffset, alignOffset, collisionPadding, etc.",
       type: "Partial<React.ComponentProps<typeof PopoverContent>>",
       required: false,
-      default: '{ align: "center" }',
+      default: '{ align: "end" }',
     },
     volumeSliderProps: {
       description: "Props forwarded to the inner BotVolumeSliderComponent (noLabel, noPercent, orientation, sliderProps, etc.)",
@@ -163,7 +163,7 @@ The `BotAudioComponent` is the headless variant. It accepts `volume` and `onVolu
       description: "Props forwarded to PopoverContent. Use to adjust placement — align, side, sideOffset, alignOffset, collisionPadding, etc.",
       type: "Partial<React.ComponentProps<typeof PopoverContent>>",
       required: false,
-      default: '{ align: "center" }',
+      default: '{ align: "end" }',
     },
     volumeSliderProps: {
       description: "Props forwarded to the inner BotVolumeSliderComponent (noLabel, noPercent, orientation, sliderProps, etc.)",
@@ -207,8 +207,8 @@ Pass `popoverContentProps` to override placement defaults:
 ```tsx
 <BotAudioControl
   popoverContentProps={{
-    align: "end",
-    side: "bottom",
+    align: "center",
+    side: "top",
     sideOffset: 8,
   }}
 />

--- a/docs/content/docs/components/BotAudioControl.mdx
+++ b/docs/content/docs/components/BotAudioControl.mdx
@@ -226,7 +226,7 @@ Pass `popoverProps` to control open state (e.g. for a controlled popover):
 
 The connected `BotAudioControl` reads and writes volume through the [`useBotAudioOutput`](/hooks/useBotAudioOutput) hook, and uses `usePipecatClientTransportState` to disable the control while the transport is disconnected or initializing. It must be used within a `PipecatClientProvider` context (typically provided by `PipecatAppBase`).
 
-Volume is applied to the `<audio>` element rendered by `BotAudioOutput`, which `PipecatAppBase` mounts in place of `PipecatClientAudio` unless `noAudioOutput` is `true`.
+Volume is applied to the `<audio>` element rendered by `BotAudioOutput`, which `PipecatAppBase` mounts automatically unless `noAudioOutput` is `true`.
 
 ## Visual States
 

--- a/docs/content/docs/components/BotVolumeSlider.mdx
+++ b/docs/content/docs/components/BotVolumeSlider.mdx
@@ -1,0 +1,162 @@
+---
+title: Bot Volume Slider
+description: Inline slider for controlling the bot's audio output volume
+component: BotVolumeSlider
+---
+
+The `BotVolumeSlider` component is an inline volume slider for the bot's audio output. It is the same slider that lives inside [`BotAudioControl`](/components/BotAudioControl)'s popover, extracted so you can embed it standalone — for example in a settings panel, a sidebar, or a custom toolbar.
+
+<LiveComponent language="tsx" withPipecat>
+{`
+  import { BotVolumeSlider } from "@pipecat-ai/voice-ui-kit";
+
+  <div style={{ width: 280 }}>
+    <BotVolumeSlider />
+  </div>
+`}
+</LiveComponent>
+
+---
+
+<TypeTable
+  className="text-sm"
+  type={{
+    noLabel: {
+      description: "Hide the label + percent readout row",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
+    noPercent: {
+      description: "Hide just the percent readout (keeps the label)",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
+    label: {
+      description: "Override the label text",
+      type: "string",
+      required: false,
+      default: '"Bot volume"',
+    },
+    orientation: {
+      description: "Slider orientation",
+      type: '"horizontal" | "vertical"',
+      required: false,
+      default: '"horizontal"',
+    },
+    className: {
+      description: "Classes for the outer wrapper",
+      type: "string",
+      required: false,
+      default: "undefined",
+    },
+    classNames: {
+      description: "Classes for individual parts of the component",
+      type: "{ labelRow?: string; label?: string; percent?: string; slider?: string; }",
+      required: false,
+      default: "undefined",
+    },
+    sliderProps: {
+      description: "Props forwarded to the underlying Slider primitive",
+      type: "Partial<React.ComponentProps<typeof Slider>>",
+      required: false,
+      default: "undefined",
+    },
+  }}
+/>
+
+### BotVolumeSliderComponent
+
+The `BotVolumeSliderComponent` is the headless variant. It accepts `volume` and `onVolumeChange` directly, so you can drive it from any state source.
+
+<LiveComponent language="tsx" noInline>
+{`
+  import { BotVolumeSliderComponent } from "@pipecat-ai/voice-ui-kit";
+
+  function Demo() {
+    const [volume, setVolume] = React.useState(0.8);
+    return (
+      <div style={{ width: 280 }}>
+        <BotVolumeSliderComponent
+          volume={volume}
+          onVolumeChange={setVolume}
+        />
+      </div>
+    );
+  }
+
+  render(<Demo />);
+`}
+</LiveComponent>
+
+<TypeTable
+  className="text-sm"
+  type={{
+    volume: {
+      description: "Current volume, in the range 0.0 – 1.0",
+      type: "number",
+      required: false,
+      default: "1",
+    },
+    onVolumeChange: {
+      description: "Callback fired when the user changes the volume. Receives a value in the range 0.0 – 1.0",
+      type: "(volume: number) => void",
+      required: false,
+      default: "undefined",
+    },
+    noLabel: {
+      description: "Hide the label + percent readout row",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
+    noPercent: {
+      description: "Hide just the percent readout (keeps the label)",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
+    label: {
+      description: "Override the label text",
+      type: "string",
+      required: false,
+      default: '"Bot volume"',
+    },
+    orientation: {
+      description: "Slider orientation",
+      type: '"horizontal" | "vertical"',
+      required: false,
+      default: '"horizontal"',
+    },
+    className: {
+      description: "Classes for the outer wrapper",
+      type: "string",
+      required: false,
+      default: "undefined",
+    },
+    classNames: {
+      description: "Classes for individual parts of the component",
+      type: "{ labelRow?: string; label?: string; percent?: string; slider?: string; }",
+      required: false,
+      default: "undefined",
+    },
+    sliderProps: {
+      description: "Props forwarded to the underlying Slider primitive",
+      type: "Partial<React.ComponentProps<typeof Slider>>",
+      required: false,
+      default: "undefined",
+    },
+  }}
+/>
+
+---
+
+## Integration
+
+The connected `BotVolumeSlider` reads and writes volume through the [`useBotAudioOutput`](/hooks/useBotAudioOutput) hook. It does not require `PipecatClientProvider` to render, but needs `BotAudioOutput` to be mounted somewhere in the tree for the volume to have any audible effect — handled by `PipecatAppBase` unless you pass `noAudioOutput`.
+
+## See Also
+
+- [`BotAudioControl`](/components/BotAudioControl) — a button + popover that wraps this slider.
+- [`useBotAudioOutput`](/hooks/useBotAudioOutput) — the underlying hook.

--- a/docs/content/docs/components/PipecatAppBase.mdx
+++ b/docs/content/docs/components/PipecatAppBase.mdx
@@ -11,7 +11,7 @@ It handles the common setup tasks that are typically the same across most applic
 - Creates a Pipecat Client instance and manages its lifecycle.
 - Wraps children with the necessary providers (such as `ThemeProvider` and `PipecatClientProvider`).
 - Provides connect and disconnect handlers (sync or async).
-- Mounts any available audio tracks using the Pipecat React `<PipecatClientAudio />` component.
+- Mounts the bot audio track via `<BotAudioOutput />`, which also binds playback volume to `useBotAudioOutput`.
 - Passes through transport and client options from the constructor.
 - Automatically disconnects and disposes the client when unmounting.
 - Surfaces error states to the child components.
@@ -277,7 +277,7 @@ export default function Home() {
     },
     noAudioOutput: {
       description:
-        "Whether to disable audio output for the bot. When true, the PipecatClientAudio component is not rendered.",
+        "Whether to disable audio output for the bot. When true, no bot audio element is rendered.",
       type: "boolean",
       default: "false",
       required: false,

--- a/docs/content/docs/components/meta.json
+++ b/docs/content/docs/components/meta.json
@@ -1,6 +1,8 @@
 {
     "pages": [
         "overview",
+        "BotAudioControl",
+        "BotVolumeSlider",
         "ClientStatus",
         "ConnectButton",
         "Conversation",

--- a/docs/content/docs/hooks/useBotAudioOutput.mdx
+++ b/docs/content/docs/hooks/useBotAudioOutput.mdx
@@ -1,0 +1,48 @@
+---
+title: useBotAudioOutput
+description: Hook for reading and updating the bot's audio output volume
+---
+
+The `useBotAudioOutput` hook exposes the bot audio output state that drives the `<audio>` element rendered by `BotAudioOutput`. Use it to read the current volume or to set it from anywhere in your app — the `BotAudioControl` component and any other consumer stay in sync automatically.
+
+## Usage
+
+```tsx
+import { useBotAudioOutput } from "@pipecat-ai/voice-ui-kit";
+
+function VolumeReadout() {
+  const { volume, setVolume } = useBotAudioOutput();
+  return (
+    <div>
+      <p>Bot volume: {Math.round(volume * 100)}%</p>
+      <button onClick={() => setVolume(0.5)}>Set to 50%</button>
+    </div>
+  );
+}
+```
+
+## Return Value
+
+<TypeTable
+  className="text-sm"
+  type={{
+    volume: {
+      description: "Current bot audio output volume, in the range 0.0 – 1.0",
+      type: "number",
+      required: true,
+    },
+    setVolume: {
+      description: "Set the bot audio output volume. Values are clamped to [0, 1]",
+      type: "(volume: number) => void",
+      required: true,
+    },
+  }}
+/>
+
+## Integration
+
+The hook is backed by a module-scoped Zustand store, so it does not require a provider. It does, however, need `BotAudioOutput` to be mounted somewhere in the tree to have any audible effect — this is handled by `PipecatAppBase` unless you pass `noAudioOutput`.
+
+## See Also
+
+- [`BotAudioControl`](/components/BotAudioControl) — a ready-made UI for changing the bot volume.

--- a/docs/content/docs/panels/BotAudioPanel.mdx
+++ b/docs/content/docs/panels/BotAudioPanel.mdx
@@ -33,6 +33,12 @@ The BotAudioPanel component displays a visual representation of the bot's audio 
       required: false,
       default: "false",
     },
+    noControls: {
+      description: "Hide the bot audio controls (e.g. volume) rendered in the panel header",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
   }}
 />
 

--- a/docs/content/docs/templates/console.mdx
+++ b/docs/content/docs/templates/console.mdx
@@ -163,6 +163,12 @@ The ConsoleTemplate extends `PipecatBaseProps` and adds additional configuration
       required: false,
       default: "false",
     },
+    noBotAudioControls: {
+      description: "Hides the bot audio controls (e.g. volume) in the bot audio panel header. Implicitly hidden when noAudioOutput is true",
+      type: "boolean",
+      required: false,
+      default: "false",
+    },
     noBotVideo: {
       description: "Disables video visualization for the bot",
       type: "boolean",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,12 +17,18 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "fumadocs-mdx:collections/*": [".source/*"],
-      "@/.source": ["./.source/index.ts"],
-      "@/*": ["./*"]
+      "fumadocs-mdx:collections/*": [
+        ".source/*"
+      ],
+      "@/.source": [
+        "./.source/index.ts"
+      ],
+      "@/*": [
+        "./*"
+      ]
     },
     "plugins": [
       {
@@ -26,6 +36,14 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/examples/01-console/tsconfig.json
+++ b/examples/01-console/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package/package.json
+++ b/package/package.json
@@ -95,6 +95,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/package/src/__tests__/stores/botAudioStore.test.ts
+++ b/package/src/__tests__/stores/botAudioStore.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBotAudioStore } from "@/stores/botAudioStore";
+
+function getState() {
+  return useBotAudioStore.getState();
+}
+
+describe("botAudioStore", () => {
+  beforeEach(() => {
+    useBotAudioStore.setState({ volume: 1 });
+  });
+
+  describe("initial state", () => {
+    it("defaults volume to 1", () => {
+      expect(getState().volume).toBe(1);
+    });
+  });
+
+  describe("setVolume", () => {
+    it("accepts values inside the [0, 1] range", () => {
+      getState().setVolume(0.5);
+      expect(getState().volume).toBe(0.5);
+
+      getState().setVolume(0);
+      expect(getState().volume).toBe(0);
+
+      getState().setVolume(1);
+      expect(getState().volume).toBe(1);
+    });
+
+    it("clamps values above 1 down to 1", () => {
+      getState().setVolume(1.5);
+      expect(getState().volume).toBe(1);
+
+      getState().setVolume(42);
+      expect(getState().volume).toBe(1);
+
+      getState().setVolume(Number.POSITIVE_INFINITY);
+      expect(getState().volume).toBe(1);
+    });
+
+    it("clamps negative values up to 0", () => {
+      getState().setVolume(-0.1);
+      expect(getState().volume).toBe(0);
+
+      getState().setVolume(-100);
+      expect(getState().volume).toBe(0);
+
+      getState().setVolume(Number.NEGATIVE_INFINITY);
+      expect(getState().volume).toBe(0);
+    });
+
+    it("coerces NaN to 0", () => {
+      getState().setVolume(Number.NaN);
+      expect(getState().volume).toBe(0);
+    });
+
+    it("is idempotent when called repeatedly with the same value", () => {
+      getState().setVolume(0.3);
+      getState().setVolume(0.3);
+      getState().setVolume(0.3);
+      expect(getState().volume).toBe(0.3);
+    });
+
+    it("lets later calls override earlier ones", () => {
+      getState().setVolume(0.25);
+      expect(getState().volume).toBe(0.25);
+      getState().setVolume(0.75);
+      expect(getState().volume).toBe(0.75);
+    });
+  });
+});

--- a/package/src/components/BotAudioOutput.tsx
+++ b/package/src/components/BotAudioOutput.tsx
@@ -44,14 +44,18 @@ export const BotAudioOutput: React.FC = () => {
     el.volume = volume;
   }, [volume]);
 
-  // Mirror PipecatClientAudio's speaker routing behavior.
+  // Mirror PipecatClientAudio's speaker routing behavior. `setSinkId` returns
+  // a Promise that can reject (unsupported deviceId, permission denied, etc.);
+  // swallow and log so failures stay non-fatal and observable.
   useRTVIClientEvent(
     RTVIEvent.SpeakerUpdated,
     useCallback((speaker: MediaDeviceInfo) => {
       const el = audioRef.current;
       if (!el) return;
       if (typeof el.setSinkId !== "function") return;
-      el.setSinkId(speaker.deviceId);
+      el.setSinkId(speaker.deviceId).catch((err: unknown) => {
+        console.warn("BotAudioOutput: setSinkId failed", err);
+      });
     }, []),
   );
 

--- a/package/src/components/BotAudioOutput.tsx
+++ b/package/src/components/BotAudioOutput.tsx
@@ -1,0 +1,63 @@
+import { useBotAudioStore } from "@/stores/botAudioStore";
+import { RTVIEvent } from "@pipecat-ai/client-js";
+import {
+  usePipecatClientMediaTrack,
+  useRTVIClientEvent,
+} from "@pipecat-ai/client-react";
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Renders the bot's audio output and binds its volume to
+ * {@link useBotAudioStore}.
+ *
+ * Functionally equivalent to `PipecatClientAudio` from
+ * `@pipecat-ai/client-react` (attaches the bot's audio MediaStreamTrack to an
+ * `<audio>` element and responds to `SpeakerUpdated` via `setSinkId`), with
+ * the addition that `audio.volume` is driven by the bot audio store so it
+ * can be controlled via `BotAudioControl` / `useBotAudioOutput`.
+ *
+ * Rendered by `PipecatAppBase` in place of `PipecatClientAudio` unless
+ * `noAudioOutput` is set.
+ */
+export const BotAudioOutput: React.FC = () => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const botAudioTrack = usePipecatClientMediaTrack("audio", "bot");
+  const volume = useBotAudioStore((s) => s.volume);
+
+  // Attach the bot's audio track to the <audio> element, de-duping on track id
+  // so we don't tear down an already-playing stream.
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el || !botAudioTrack) return;
+    const existing = el.srcObject as MediaStream | null;
+    if (existing) {
+      const oldTrack = existing.getAudioTracks()[0];
+      if (oldTrack && oldTrack.id === botAudioTrack.id) return;
+    }
+    el.srcObject = new MediaStream([botAudioTrack]);
+  }, [botAudioTrack]);
+
+  // Bind store volume to the media element.
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    el.volume = volume;
+  }, [volume]);
+
+  // Mirror PipecatClientAudio's speaker routing behavior.
+  useRTVIClientEvent(
+    RTVIEvent.SpeakerUpdated,
+    useCallback((speaker: MediaDeviceInfo) => {
+      const el = audioRef.current;
+      if (!el) return;
+      if (typeof el.setSinkId !== "function") return;
+      el.setSinkId(speaker.deviceId);
+    }, []),
+  );
+
+  return <audio ref={audioRef} autoPlay />;
+};
+
+BotAudioOutput.displayName = "BotAudioOutput";
+
+export default BotAudioOutput;

--- a/package/src/components/PipecatAppBase.tsx
+++ b/package/src/components/PipecatAppBase.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BotAudioOutput } from "@/components/BotAudioOutput";
 import {
   ThemeProvider,
   type ThemeProviderProps,
@@ -12,10 +13,7 @@ import {
   type PipecatClientOptions,
   type TransportConnectionParams,
 } from "@pipecat-ai/client-js";
-import {
-  PipecatClientAudio,
-  PipecatClientProvider,
-} from "@pipecat-ai/client-react";
+import { PipecatClientProvider } from "@pipecat-ai/client-react";
 import type { DailyTransportConstructorOptions } from "@pipecat-ai/daily-transport";
 import type {
   SmallWebRTCTransport,
@@ -316,7 +314,7 @@ export const PipecatAppBase: React.FC<PipecatBaseProps> = ({
     <PipecatClientProvider client={client!}>
       <ConversationProvider>
         {typeof children === "function" ? children(passedProps) : children}
-        {!noAudioOutput && <PipecatClientAudio />}
+        {!noAudioOutput && <BotAudioOutput />}
       </ConversationProvider>
     </PipecatClientProvider>
   );

--- a/package/src/components/elements/BotAudioControl.stories.tsx
+++ b/package/src/components/elements/BotAudioControl.stories.tsx
@@ -1,0 +1,63 @@
+import type { ButtonSize, ButtonVariant } from "@/components/ui/buttonVariants";
+import {
+  buttonSizeOptions,
+  buttonVariantOptions,
+} from "@/components/ui/buttonVariants";
+import { Card, CardContent } from "@/components/ui/card";
+import type { Story, StoryDefault } from "@ladle/react";
+import { useState } from "react";
+import { BotAudioComponent } from "./BotAudioControl";
+
+export default {
+  title: "Components / Bot Audio Control",
+  argTypes: {
+    variant: {
+      options: buttonVariantOptions,
+      control: { type: "select" },
+      defaultValue: "secondary",
+    },
+    size: {
+      options: buttonSizeOptions,
+      control: { type: "select" },
+      defaultValue: "md",
+    },
+    noIcon: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    label: {
+      control: { type: "text" },
+      defaultValue: "",
+    },
+  },
+} satisfies StoryDefault;
+
+interface Args {
+  variant: ButtonVariant;
+  size: ButtonSize;
+  noIcon: boolean;
+  label: string;
+}
+
+export const Headless: Story<Args> = ({ variant, size, noIcon, label }) => {
+  const [volume, setVolume] = useState(0.8);
+
+  return (
+    <Card>
+      <CardContent>
+        <BotAudioComponent
+          variant={variant}
+          size={size}
+          noIcon={noIcon}
+          label={label || undefined}
+          volume={volume}
+          onVolumeChange={setVolume}
+        />
+        <p className="text-sm text-muted-foreground mt-2">
+          Volume: {Math.round(volume * 100)}%
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+Headless.storyName = "Headless (BotAudioComponent)";

--- a/package/src/components/elements/BotAudioControl.tsx
+++ b/package/src/components/elements/BotAudioControl.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { BotVolumeSliderComponent } from "@/components/elements/BotVolumeSlider";
+import { Button } from "@/components/ui/button";
+import {
+  type ButtonSize,
+  type ButtonState,
+  type ButtonVariant,
+} from "@/components/ui/buttonVariants";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useBotAudioOutput } from "@/hooks/useBotAudioOutput";
+import { cn } from "@/lib/utils";
+import { usePipecatClientTransportState } from "@pipecat-ai/client-react";
+import {
+  Volume1Icon,
+  Volume2Icon,
+  VolumeIcon,
+  VolumeXIcon,
+} from "lucide-react";
+
+/**
+ * Base props interface for BotAudioControl components.
+ */
+interface Props {
+  /** Visual style variant for the control button */
+  variant?: ButtonVariant;
+  /** Size of the control button */
+  size?: ButtonSize;
+  /** State of the control button (default, inactive, etc.) */
+  state?: ButtonState;
+  /** Additional props to pass to the control button */
+  buttonProps?: Partial<React.ComponentProps<typeof Button>>;
+  /**
+   * Props forwarded to the Radix `Popover` root (e.g. `open`, `defaultOpen`,
+   * `onOpenChange`, `modal`).
+   */
+  popoverProps?: Partial<React.ComponentProps<typeof Popover>>;
+  /**
+   * Props forwarded to `PopoverContent`. Use this to adjust placement —
+   * `align`, `side`, `sideOffset`, `alignOffset`, `collisionPadding`, etc.
+   * Defaults: `align="center"`.
+   */
+  popoverContentProps?: Partial<React.ComponentProps<typeof PopoverContent>>;
+  /**
+   * Props forwarded to the inner {@link BotVolumeSliderComponent} (e.g.
+   * `noLabel`, `noPercent`, `orientation`, `sliderProps`).
+   */
+  volumeSliderProps?: Partial<
+    Omit<
+      React.ComponentProps<typeof BotVolumeSliderComponent>,
+      "volume" | "onVolumeChange"
+    >
+  >;
+  /** Custom CSS classes for different parts of the component */
+  classNames?: {
+    /** CSS classes for the trigger button */
+    button?: string;
+    /** CSS classes for the popover content */
+    popoverContent?: string;
+    /** CSS classes for the volume slider */
+    slider?: string;
+  };
+  /** Whether to hide the volume icon in the button */
+  noIcon?: boolean;
+  /** Optional visible label rendered next to the icon */
+  label?: string;
+  /** Custom content to render inside the button (after the icon/label) */
+  children?: React.ReactNode;
+}
+
+/**
+ * Props interface for the headless BotAudioComponent.
+ */
+interface ComponentProps extends Props {
+  /** Current volume, 0.0 – 1.0 */
+  volume?: number;
+  /** Callback invoked when the volume changes (value is in 0.0 – 1.0) */
+  onVolumeChange?: (volume: number) => void;
+}
+
+/**
+ * Pick an icon that reflects the current volume level.
+ * Purely cosmetic — this does not represent a mute state.
+ */
+const iconForVolume = (
+  volume: number,
+): typeof VolumeIcon | typeof Volume1Icon | typeof Volume2Icon => {
+  if (volume <= 0) return VolumeXIcon;
+  if (volume < 0.34) return VolumeIcon;
+  if (volume < 0.67) return Volume1Icon;
+  return Volume2Icon;
+};
+
+/**
+ * Headless `BotAudioComponent` that accepts volume state and a change callback.
+ *
+ * Useful when you need full control over state (tests, custom stores, etc.)
+ * and don't want the connected `BotAudioControl` to read/write the kit's
+ * bot audio store.
+ */
+export const BotAudioComponent: React.FC<ComponentProps> = ({
+  variant = "secondary",
+  size = "md",
+  state,
+  buttonProps = {},
+  popoverProps,
+  popoverContentProps,
+  volumeSliderProps,
+  classNames = {},
+  noIcon = false,
+  label,
+  children,
+  volume = 1,
+  onVolumeChange,
+}) => {
+  const Icon = iconForVolume(volume);
+
+  return (
+    <Popover {...popoverProps}>
+      <PopoverTrigger asChild>
+        <Button
+          variant={variant}
+          size={size}
+          state={state}
+          aria-label={label ?? "Bot volume"}
+          {...buttonProps}
+          className={cn(classNames.button, buttonProps?.className)}
+        >
+          {!noIcon && <Icon />}
+          {label ? <span className="flex-1">{label}</span> : null}
+          {children}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="center"
+        {...popoverContentProps}
+        className={cn(
+          "w-56",
+          classNames.popoverContent,
+          popoverContentProps?.className,
+        )}
+      >
+        <BotVolumeSliderComponent
+          volume={volume}
+          onVolumeChange={onVolumeChange}
+          {...volumeSliderProps}
+          classNames={{
+            slider: classNames.slider,
+            ...volumeSliderProps?.classNames,
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+BotAudioComponent.displayName = "BotAudioComponent";
+
+/**
+ * Connected `BotAudioControl` wired to the kit's bot audio store and the
+ * Pipecat client transport state.
+ *
+ * Must be used within a `PipecatClientProvider` (typically via
+ * `PipecatAppBase`). The control becomes disabled while the transport is
+ * disconnected or initializing.
+ *
+ * @example
+ * ```tsx
+ * <BotAudioControl size="sm" />
+ * ```
+ */
+export const BotAudioControl: React.FC<Props> = ({ buttonProps, ...props }) => {
+  const { volume, setVolume } = useBotAudioOutput();
+  const transportState = usePipecatClientTransportState();
+  const loading =
+    transportState === "disconnected" || transportState === "initializing";
+
+  return (
+    <BotAudioComponent
+      volume={volume}
+      onVolumeChange={setVolume}
+      buttonProps={{
+        isLoading: loading,
+        ...buttonProps,
+      }}
+      {...props}
+    />
+  );
+};
+
+BotAudioControl.displayName = "BotAudioControl";
+
+export default BotAudioControl;

--- a/package/src/components/elements/BotAudioControl.tsx
+++ b/package/src/components/elements/BotAudioControl.tsx
@@ -126,7 +126,7 @@ export const BotAudioComponent: React.FC<ComponentProps> = ({
           variant={variant}
           size={size}
           state={state}
-          aria-label={label ?? "Bot volume"}
+          aria-label={label?.trim() || "Bot volume"}
           {...buttonProps}
           className={cn(classNames.button, buttonProps?.className)}
         >

--- a/package/src/components/elements/BotAudioControl.tsx
+++ b/package/src/components/elements/BotAudioControl.tsx
@@ -42,7 +42,7 @@ interface Props {
   /**
    * Props forwarded to `PopoverContent`. Use this to adjust placement —
    * `align`, `side`, `sideOffset`, `alignOffset`, `collisionPadding`, etc.
-   * Defaults: `align="center"`.
+   * Defaults: `align="end"`.
    */
   popoverContentProps?: Partial<React.ComponentProps<typeof PopoverContent>>;
   /**
@@ -136,7 +136,7 @@ export const BotAudioComponent: React.FC<ComponentProps> = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        align="center"
+        align="end"
         {...popoverContentProps}
         className={cn(
           "w-56",

--- a/package/src/components/elements/BotVolumeSlider.stories.tsx
+++ b/package/src/components/elements/BotVolumeSlider.stories.tsx
@@ -1,0 +1,64 @@
+import { Card, CardContent } from "@/components/ui/card";
+import type { Story, StoryDefault } from "@ladle/react";
+import { useState } from "react";
+import { BotVolumeSliderComponent } from "./BotVolumeSlider";
+
+export default {
+  title: "Components / Bot Volume Slider",
+  argTypes: {
+    noLabel: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    noPercent: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    orientation: {
+      options: ["horizontal", "vertical"],
+      control: { type: "select" },
+      defaultValue: "horizontal",
+    },
+    label: {
+      control: { type: "text" },
+      defaultValue: "Bot volume",
+    },
+  },
+} satisfies StoryDefault;
+
+interface Args {
+  noLabel: boolean;
+  noPercent: boolean;
+  orientation: "horizontal" | "vertical";
+  label: string;
+}
+
+export const Headless: Story<Args> = ({
+  noLabel,
+  noPercent,
+  orientation,
+  label,
+}) => {
+  const [volume, setVolume] = useState(0.8);
+
+  return (
+    <Card>
+      <CardContent>
+        <div
+          style={orientation === "vertical" ? { height: 200 } : { width: 280 }}
+        >
+          <BotVolumeSliderComponent
+            volume={volume}
+            onVolumeChange={setVolume}
+            noLabel={noLabel}
+            noPercent={noPercent}
+            orientation={orientation}
+            label={label}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+Headless.storyName = "Headless (BotVolumeSliderComponent)";

--- a/package/src/components/elements/BotVolumeSlider.tsx
+++ b/package/src/components/elements/BotVolumeSlider.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Slider } from "@/components/ui/slider";
+import { useBotAudioOutput } from "@/hooks/useBotAudioOutput";
+import { cn } from "@/lib/utils";
+
+/**
+ * Base props shared by the connected and headless variants.
+ */
+interface Props {
+  /** Hide the label + percent readout row. Default: false */
+  noLabel?: boolean;
+  /** Hide just the percent readout (keeps the label). Default: false */
+  noPercent?: boolean;
+  /** Override the label text. Default: `"Bot volume"` */
+  label?: string;
+  /** Slider orientation. Default: `"horizontal"` */
+  orientation?: "horizontal" | "vertical";
+  /** Classes for the outer wrapper */
+  className?: string;
+  /** Classes for individual parts */
+  classNames?: {
+    /** Classes for the label row */
+    labelRow?: string;
+    /** Classes for the label text */
+    label?: string;
+    /** Classes for the percent readout */
+    percent?: string;
+    /** Classes for the slider itself */
+    slider?: string;
+  };
+  /** Props forwarded to the underlying Slider primitive */
+  sliderProps?: Partial<React.ComponentProps<typeof Slider>>;
+}
+
+/**
+ * Props for the headless {@link BotVolumeSliderComponent}.
+ */
+interface ComponentProps extends Props {
+  /** Current volume, 0.0 – 1.0 */
+  volume?: number;
+  /** Callback fired when the volume changes. Receives 0.0 – 1.0 */
+  onVolumeChange?: (volume: number) => void;
+}
+
+/**
+ * Headless bot volume slider. Accepts `volume` + `onVolumeChange` directly,
+ * so you can drive it from any state source (tests, custom stores, etc.).
+ */
+export const BotVolumeSliderComponent: React.FC<ComponentProps> = ({
+  volume = 1,
+  onVolumeChange,
+  noLabel = false,
+  noPercent = false,
+  label = "Bot volume",
+  orientation = "horizontal",
+  className,
+  classNames = {},
+  sliderProps,
+}) => {
+  const pct = Math.round(volume * 100);
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      {!noLabel && (
+        <div
+          className={cn(
+            "flex items-center justify-between text-sm",
+            classNames.labelRow,
+          )}
+        >
+          <span className={cn("text-muted-foreground", classNames.label)}>
+            {label}
+          </span>
+          {!noPercent && (
+            <span
+              className={cn("font-medium tabular-nums", classNames.percent)}
+            >
+              {pct}%
+            </span>
+          )}
+        </div>
+      )}
+      <Slider
+        min={0}
+        max={1}
+        step={0.01}
+        value={[volume]}
+        onValueChange={(v) => onVolumeChange?.(v[0] ?? 0)}
+        orientation={orientation}
+        aria-label={label}
+        {...sliderProps}
+        className={cn(classNames.slider, sliderProps?.className)}
+      />
+    </div>
+  );
+};
+
+BotVolumeSliderComponent.displayName = "BotVolumeSliderComponent";
+
+/**
+ * Connected bot volume slider wired to the kit's bot audio store
+ * ({@link useBotAudioOutput}). Drop it anywhere inside `PipecatAppBase` for
+ * an inline volume control; `BotAudioControl` composes it inside a popover.
+ *
+ * @example
+ * ```tsx
+ * <BotVolumeSlider />
+ * <BotVolumeSlider noLabel />
+ * <BotVolumeSlider orientation="vertical" className="h-40" />
+ * ```
+ */
+export const BotVolumeSlider: React.FC<Props> = (props) => {
+  const { volume, setVolume } = useBotAudioOutput();
+  return (
+    <BotVolumeSliderComponent
+      volume={volume}
+      onVolumeChange={setVolume}
+      {...props}
+    />
+  );
+};
+
+BotVolumeSlider.displayName = "BotVolumeSlider";
+
+export default BotVolumeSlider;

--- a/package/src/components/elements/BotVolumeSlider.tsx
+++ b/package/src/components/elements/BotVolumeSlider.tsx
@@ -59,6 +59,9 @@ export const BotVolumeSliderComponent: React.FC<ComponentProps> = ({
   sliderProps,
 }) => {
   const pct = Math.round(volume * 100);
+  // Guard the accessible name: an empty or whitespace-only `label` would
+  // leave the slider unannounced for assistive tech.
+  const accessibleLabel = label.trim() || "Bot volume";
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
@@ -86,9 +89,9 @@ export const BotVolumeSliderComponent: React.FC<ComponentProps> = ({
         max={1}
         step={0.01}
         value={[volume]}
-        onValueChange={(v) => onVolumeChange?.(v[0] ?? 0)}
+        onValueChange={(v: number[]) => onVolumeChange?.(v[0] ?? 0)}
         orientation={orientation}
-        aria-label={label}
+        aria-label={accessibleLabel}
         {...sliderProps}
         className={cn(classNames.slider, sliderProps?.className)}
       />

--- a/package/src/components/elements/index.ts
+++ b/package/src/components/elements/index.ts
@@ -1,3 +1,5 @@
+export * from "./BotAudioControl";
+export * from "./BotVolumeSlider";
 export * from "./ClientStatus";
 export * from "./ConnectButton";
 export * from "./ControlBar";

--- a/package/src/components/panels/BotAudioPanel.tsx
+++ b/package/src/components/panels/BotAudioPanel.tsx
@@ -81,7 +81,7 @@ export const BotAudioPanel: React.FC<BotAudioPanelProps> = ({
       )}
     >
       {!collapsed && (
-        <PanelHeader className="flex items-center justify-between gap-2">
+        <PanelHeader className={cn(!noControls && "justify-between gap-2")}>
           <PanelTitle>Bot Audio</PanelTitle>
           {!noControls && <BotAudioControl size="sm" variant="ghost" />}
         </PanelHeader>

--- a/package/src/components/panels/BotAudioPanel.tsx
+++ b/package/src/components/panels/BotAudioPanel.tsx
@@ -17,13 +17,15 @@ interface BotAudioPanelProps {
   collapsed?: boolean;
   visualization?: "bar" | "circle";
   /**
-   * Reserved for a future mute affordance. Currently unwired — see plan notes.
-   * @deprecated Not yet implemented. Will be used when mute semantics are finalized.
+   * Reserved for a future mute affordance. Currently a no-op; will be wired
+   * up once the mute design (local playback vs. conversation pause vs.
+   * server-side TTS suppression) is finalized.
    */
   isMuted?: boolean;
   /**
-   * Reserved for a future mute affordance. Currently unwired — see plan notes.
-   * @deprecated Not yet implemented. Will be used when mute semantics are finalized.
+   * Reserved for a future mute affordance. Currently a no-op; will be wired
+   * up once the mute design (local playback vs. conversation pause vs.
+   * server-side TTS suppression) is finalized.
    */
   onMuteToggle?: () => void;
   /** Hide the header bot audio controls (e.g. volume). Defaults to `false`. */

--- a/package/src/components/panels/BotAudioPanel.tsx
+++ b/package/src/components/panels/BotAudioPanel.tsx
@@ -1,3 +1,4 @@
+import { BotAudioControl } from "@/components/elements/BotAudioControl";
 import {
   Panel,
   PanelContent,
@@ -15,8 +16,18 @@ interface BotAudioPanelProps {
   className?: string;
   collapsed?: boolean;
   visualization?: "bar" | "circle";
+  /**
+   * Reserved for a future mute affordance. Currently unwired — see plan notes.
+   * @deprecated Not yet implemented. Will be used when mute semantics are finalized.
+   */
   isMuted?: boolean;
+  /**
+   * Reserved for a future mute affordance. Currently unwired — see plan notes.
+   * @deprecated Not yet implemented. Will be used when mute semantics are finalized.
+   */
   onMuteToggle?: () => void;
+  /** Hide the header bot audio controls (e.g. volume). Defaults to `false`. */
+  noControls?: boolean;
 }
 
 const barCount = 10;
@@ -24,6 +35,7 @@ const barCount = 10;
 export const BotAudioPanel: React.FC<BotAudioPanelProps> = ({
   className,
   collapsed = false,
+  noControls = false,
 }) => {
   const track = usePipecatClientMediaTrack("audio", "bot");
 
@@ -69,8 +81,9 @@ export const BotAudioPanel: React.FC<BotAudioPanelProps> = ({
       )}
     >
       {!collapsed && (
-        <PanelHeader>
+        <PanelHeader className="flex items-center justify-between gap-2">
           <PanelTitle>Bot Audio</PanelTitle>
+          {!noControls && <BotAudioControl size="sm" variant="ghost" />}
         </PanelHeader>
       )}
       <PanelContent

--- a/package/src/components/panels/BotAudioPanel.tsx
+++ b/package/src/components/panels/BotAudioPanel.tsx
@@ -16,17 +16,7 @@ interface BotAudioPanelProps {
   className?: string;
   collapsed?: boolean;
   visualization?: "bar" | "circle";
-  /**
-   * Reserved for a future mute affordance. Currently a no-op; will be wired
-   * up once the mute design (local playback vs. conversation pause vs.
-   * server-side TTS suppression) is finalized.
-   */
   isMuted?: boolean;
-  /**
-   * Reserved for a future mute affordance. Currently a no-op; will be wired
-   * up once the mute design (local playback vs. conversation pause vs.
-   * server-side TTS suppression) is finalized.
-   */
   onMuteToggle?: () => void;
   /** Hide the header bot audio controls (e.g. volume). Defaults to `false`. */
   noControls?: boolean;

--- a/package/src/components/ui/index.ts
+++ b/package/src/components/ui/index.ts
@@ -18,6 +18,7 @@ export * from "./popover";
 export * from "./progress";
 export * from "./resizable";
 export * from "./select";
+export * from "./slider";
 export * from "./tabs";
 export * from "./textarea";
 export * from "./tooltip";

--- a/package/src/components/ui/slider.stories.tsx
+++ b/package/src/components/ui/slider.stories.tsx
@@ -1,0 +1,48 @@
+import type { Story, StoryDefault } from "@ladle/react";
+import { useState } from "react";
+import { Slider } from "./slider";
+
+export default {
+  title: "Primitives",
+} satisfies StoryDefault;
+
+export const SliderStory: Story = () => {
+  const [horizontal, setHorizontal] = useState<number[]>([50]);
+  const [vertical, setVertical] = useState<number[]>([25]);
+
+  return (
+    <div className="ladle-section-container">
+      <h3 className="ladle-section-header">Horizontal</h3>
+      <div className="ladle-section" style={{ width: 320 }}>
+        <Slider
+          min={0}
+          max={100}
+          step={1}
+          value={horizontal}
+          onValueChange={setHorizontal}
+        />
+        <p className="text-sm text-muted-foreground">Value: {horizontal[0]}</p>
+      </div>
+
+      <h3 className="ladle-section-header">Vertical</h3>
+      <div className="ladle-section" style={{ height: 160 }}>
+        <Slider
+          orientation="vertical"
+          min={0}
+          max={100}
+          step={1}
+          value={vertical}
+          onValueChange={setVertical}
+        />
+        <p className="text-sm text-muted-foreground">Value: {vertical[0]}</p>
+      </div>
+
+      <h3 className="ladle-section-header">Disabled</h3>
+      <div className="ladle-section" style={{ width: 320 }}>
+        <Slider disabled value={[40]} min={0} max={100} />
+      </div>
+    </div>
+  );
+};
+
+SliderStory.storyName = "Slider";

--- a/package/src/components/ui/slider.tsx
+++ b/package/src/components/ui/slider.tsx
@@ -13,7 +13,7 @@ const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
 >(({ className, orientation = "horizontal", ...props }, ref) => {
-  const values = Array.isArray(props.value)
+  const values: number[] = Array.isArray(props.value)
     ? props.value
     : Array.isArray(props.defaultValue)
       ? props.defaultValue

--- a/package/src/components/ui/slider.tsx
+++ b/package/src/components/ui/slider.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A thin wrapper around Radix Slider styled to match the rest of the kit.
+ * Supports horizontal or vertical orientation.
+ */
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, orientation = "horizontal", ...props }, ref) => {
+  const values = Array.isArray(props.value)
+    ? props.value
+    : Array.isArray(props.defaultValue)
+      ? props.defaultValue
+      : [0];
+
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      data-slot="slider"
+      orientation={orientation}
+      className={cn(
+        "relative flex touch-none select-none items-center",
+        orientation === "horizontal"
+          ? "w-full h-5"
+          : "h-32 w-5 flex-col justify-center",
+        "data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "relative grow overflow-hidden rounded-full bg-primary/20",
+          orientation === "horizontal" ? "h-1.5 w-full" : "w-1.5 h-full",
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "absolute bg-primary",
+            orientation === "horizontal" ? "h-full" : "w-full",
+          )}
+        />
+      </SliderPrimitive.Track>
+      {values.map((_, i) => (
+        <SliderPrimitive.Thumb
+          key={i}
+          data-slot="slider-thumb"
+          className="block size-4 rounded-full border border-primary/50 bg-background shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+});
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -1,4 +1,8 @@
 export {
+  useBotAudioOutput,
+  type UseBotAudioOutputReturn,
+} from "./useBotAudioOutput";
+export {
   usePipecatConnectionState,
   type PipecatConnectionState,
 } from "./usePipecatConnectionState";

--- a/package/src/hooks/useBotAudioOutput.ts
+++ b/package/src/hooks/useBotAudioOutput.ts
@@ -1,0 +1,28 @@
+import { useBotAudioStore } from "@/stores/botAudioStore";
+
+/**
+ * Return shape of {@link useBotAudioOutput}.
+ */
+export interface UseBotAudioOutputReturn {
+  /** Current bot audio output volume, 0.0 – 1.0. */
+  volume: number;
+  /** Set the bot audio output volume. Values are clamped to [0, 1]. */
+  setVolume: (volume: number) => void;
+}
+
+/**
+ * Access and update the bot's audio output state.
+ *
+ * Pairs with the `BotAudioOutput` component (rendered by `PipecatAppBase`)
+ * and the `BotAudioControl` component. Returns the current volume and a
+ * setter; any consumer can read or drive the volume without prop drilling.
+ *
+ * ```tsx
+ * const { volume, setVolume } = useBotAudioOutput();
+ * ```
+ */
+export const useBotAudioOutput = (): UseBotAudioOutputReturn => {
+  const volume = useBotAudioStore((s) => s.volume);
+  const setVolume = useBotAudioStore((s) => s.setVolume);
+  return { volume, setVolume };
+};

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,4 +1,5 @@
 // Components
+export * from "@/components/BotAudioOutput";
 export * from "@/components/elements";
 export * from "@/components/panels";
 export * from "@/components/PipecatAppBase";

--- a/package/src/stores/botAudioStore.ts
+++ b/package/src/stores/botAudioStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+/**
+ * Clamp a volume value to the valid HTMLMediaElement range [0, 1].
+ */
+const clampVolume = (v: number): number => {
+  if (Number.isNaN(v)) return 0;
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+};
+
+interface BotAudioState {
+  /** Current bot audio output volume, 0.0 – 1.0. */
+  volume: number;
+  /** Set the bot audio output volume. Values are clamped to [0, 1]. */
+  setVolume: (volume: number) => void;
+}
+
+/**
+ * Store for bot audio output state.
+ *
+ * Drives the `<audio>` element rendered by `BotAudioOutput` and is read by
+ * `BotAudioControl`. Kept as a module-level store so any number of control
+ * instances stay in sync without prop drilling.
+ *
+ * Mute is intentionally not modeled here yet — see plan notes.
+ */
+export const useBotAudioStore = create<BotAudioState>()((set) => ({
+  volume: 1,
+  setVolume: (volume) => set({ volume: clampVolume(volume) }),
+}));

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -83,6 +83,11 @@ export interface ConsoleTemplateProps
   noAudioOutput?: boolean;
   /** Disables audio visualization for the bot. Default: false */
   noBotAudio?: boolean;
+  /**
+   * Hides the bot audio controls (e.g. volume) in the bot audio panel header.
+   * Implicitly hidden when `noAudioOutput` is true. Default: false
+   */
+  noBotAudioControls?: boolean;
   /** Disables video visualization for the bot. Default: true */
   noBotVideo?: boolean;
   /** Disables automatic initialization of devices. Default: false */
@@ -289,7 +294,9 @@ const ConsoleUI = ({
   noScreenControl = false,
   noTextInput = false,
   noBotAudio = false,
+  noBotAudioControls = false,
   noBotVideo = false,
+  noAudioOutput = false,
 
   // Transport and client options
   startBotParams,
@@ -462,6 +469,7 @@ const ConsoleUI = ({
                             "mb-auto": noBotVideo,
                           })}
                           collapsed={isBotAreaCollapsed}
+                          noControls={noBotAudioControls || noAudioOutput}
                         />
                       )}
                       {!noBotVideo && (
@@ -600,7 +608,11 @@ const ConsoleUI = ({
                 value="bot"
                 className="flex-1 overflow-auto flex flex-col gap-4 p-2"
               >
-                {!noBotAudio && <BotAudioPanel />}
+                {!noBotAudio && (
+                  <BotAudioPanel
+                    noControls={noBotAudioControls || noAudioOutput}
+                  />
+                )}
                 {!noBotVideo && <BotVideoPanel />}
               </TabsContent>
             )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slider':
+        specifier: ^1.3.6
+        version: 1.3.6(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.16)(react@19.2.1)
@@ -2008,6 +2011,19 @@ packages:
 
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8166,6 +8182,25 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-remove-scroll: 2.7.1(@types/react@19.1.16)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.16
+      '@types/react-dom': 19.1.9(@types/react@19.1.16)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.16)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.1.16
       '@types/react-dom': 19.1.9(@types/react@19.1.16)


### PR DESCRIPTION
## Summary

- Adds a bot audio output volume control: `BotAudioControl` (button + popover) and `BotVolumeSlider` (standalone inline slider), backed by a new `useBotAudioOutput` hook and Zustand store.
- Replaces `PipecatClientAudio` with `BotAudioOutput` inside `PipecatAppBase`, so the kit drives `audio.volume` directly while preserving existing track attach and `setSinkId` behavior.
- Wires the control into `BotAudioPanel`'s header and exposes `noBotAudioControls` on `ConsoleTemplate` (also implicitly hidden when `noAudioOutput` is set).
- Adds a `Slider` UI primitive (Radix), Ladle stories, and MDX docs for the new components and hook.

## Out of scope: bot mute

Mute is intentionally not included. "Mute the bot" has three plausible meanings (local playback mute, pause the conversation, server-side TTS suppression) and picking the wrong one risks LLM context desync: the bot "speaks", the user silenced output locally, the user replies to nothing, and the LLM has it in context that it was heard. That decision deserves a dedicated pass. For now, `volume = 0` via the slider is the mute equivalent. The existing `isMuted` / `onMuteToggle` props on `BotAudioPanel` are kept but flagged `@deprecated` until the design is finalized.

## New public surface

- Components: `BotAudioControl`, `BotAudioComponent`, `BotVolumeSlider`, `BotVolumeSliderComponent`, `BotAudioOutput`.
- Hook: `useBotAudioOutput`.
- UI primitive: `Slider`.
- Props: `BotAudioPanel.noControls`, `ConsoleTemplate.noBotAudioControls`.
- Dep: `@radix-ui/react-slider@^1.3.6`.

## Test plan

- [x] `pnpm --filter @pipecat-ai/voice-ui-kit lint` is clean.
- [x] `pnpm --filter @pipecat-ai/voice-ui-kit test` passes.
- [x] `pnpm --filter @pipecat-ai/voice-ui-kit build` succeeds (tsup + CSS + DTS).
- [x] Ladle stories render: `Primitives / Slider`, `Components / Bot Audio Control / Headless`, `Components / Bot Volume Slider / Headless`.
- [x] Connect a bot in the Console example; bot audio plays normally (parity with previous `PipecatClientAudio`).
- [x] Drag the slider in the `BotAudioPanel` header: bot audio attenuates; slide to 0 to silence.
- [x] Pass `noBotAudioControls` to `ConsoleTemplate`: header control disappears.
- [x] Pass `noAudioOutput`: no audio element mounts, control implicitly hidden.
- [x] Docs site renders the new pages without broken links.