### PR TITLE
docs: per-page versioning, source links, and release-triggered updates

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -1,0 +1,200 @@
+name: Docs Update on Release
+
+# Triggered when release-please opens or updates a release PR. The job uses
+# Claude to draft documentation updates (prose, prop tables, per-page
+# changelogs, new pages for new exports) and pushes them to a sibling docs
+# PR against main. The docs PR is intentionally separate from the
+# release-please PR to avoid having release-please regenerate over our edits.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-docs:
+    # Only run on release-please's PR. Branch name pattern from
+    # release-please-action with `include-component-in-tag: false` and a
+    # single-package manifest.
+    if: startsWith(github.head_ref, 'release-please--branches--main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: docs-update-${{ github.head_ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repo (full history for tag diffs)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Determine release version and previous tag
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # release-please writes the next version into the manifest before
+          # opening the PR, so reading it from the PR head is reliable.
+          gh pr checkout "$PR_NUMBER"
+          NEXT_VERSION=$(jq -r '.package' .release-please-manifest.json)
+          git checkout main
+          PREV_TAG=$(git describe --tags --abbrev=0 --match 'v*' --exclude '*-rc*' 2>/dev/null || echo "")
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          echo "docs_branch=docs/release-v$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare docs branch
+        env:
+          DOCS_BRANCH: ${{ steps.ctx.outputs.docs_branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Reset the docs branch to current main on every run so the agent
+          # always works from the latest state.
+          git fetch origin "$DOCS_BRANCH" || true
+          git checkout -B "$DOCS_BRANCH" origin/main
+
+      - name: Collect release context
+        id: collect
+        env:
+          PREV_TAG: ${{ steps.ctx.outputs.previous_tag }}
+          NEXT_VERSION: ${{ steps.ctx.outputs.next_version }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p .release-context
+
+          # Extract just the upcoming-version section from the release PR body.
+          gh pr view "$PR_NUMBER" --json body --jq '.body' > .release-context/release-pr-body.md
+
+          # Diff of package source between previous release tag and main.
+          if [ -n "$PREV_TAG" ]; then
+            git diff "$PREV_TAG"..HEAD -- 'package/src/**' > .release-context/package-src.diff || true
+            git log --oneline "$PREV_TAG"..HEAD -- 'package/src/**' > .release-context/package-src.log || true
+          else
+            echo "(no previous tag; first release)" > .release-context/package-src.diff
+          fi
+
+          # File list of pages that already exist (helps the agent avoid duplicates).
+          find docs/content/docs -type f -name '*.mdx' | sort > .release-context/existing-pages.txt
+
+      - name: Run Claude Code to update docs
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # `claude_args` are forwarded to the headless CLI; tune as needed.
+          claude_args: |
+            --max-turns 60
+            --allowed-tools Read,Edit,Write,Bash,Grep,Glob
+          prompt: |
+            You are updating the documentation for the @pipecat-ai/voice-ui-kit
+            release v${{ steps.ctx.outputs.next_version }} (previous release:
+            ${{ steps.ctx.outputs.previous_tag }}).
+
+            ## Inputs available to you
+            - `.release-context/release-pr-body.md` — the release-please PR body,
+              which contains the proposed changelog for this release.
+            - `.release-context/package-src.diff` — the full diff of
+              `package/src/**` from the previous release to current main.
+            - `.release-context/package-src.log` — commit log for the same range.
+            - `.release-context/existing-pages.txt` — every existing docs page.
+            - `docs/content/docs/**/*.mdx` — current docs (read and edit).
+            - `package/src/**` — current source (read only).
+
+            ## What to do
+            For every change in the diff that affects a public export
+            (component, hook, util, template, visualizer, panel, primitive,
+            type), update the corresponding docs page. Specifically:
+
+            1. **Update prose & prop tables** so they match the current
+               implementation. Pay attention to renamed props, new props,
+               removed props, changed defaults, and changed types.
+            2. **Append a per-page changelog entry** to the page's frontmatter
+               under the `changelog` field. Each page's changelog is a list,
+               newest first. The new entry uses:
+                 - `version: "v${{ steps.ctx.outputs.next_version }}"`
+                 - `date: "${{ steps.ctx.outputs.today }}"`
+                 - `changes:` a list of short, user-facing bullets describing
+                   only what changed for THIS page (not the whole release).
+               Skip the changelog entry on a page if nothing on that page
+               actually changed.
+            3. **Verify the `source` frontmatter field** points to the correct
+               implementation file(s) under `package/src/`. Add or fix it if
+               wrong. Use a string for a single file, an array for multi-file
+               primitives.
+            4. **Create new docs pages** for any newly exported public API
+               that has no corresponding page. Place them in the matching
+               folder under `docs/content/docs/` (components, hooks, panels,
+               primitives, templates, visualizers). Follow the structure of
+               existing pages: frontmatter (title, description, source,
+               changelog), prose, `<TypeTable>` for props, `<LiveComponent>`
+               examples where it makes sense.
+            5. **Do not delete pages** for removed exports. Instead, add a
+               changelog entry noting the removal and add a banner at the top
+               of the page explaining the removal. Flag these in your summary.
+
+            ## Constraints
+            - Edit only files under `docs/content/docs/` and (for source
+              verification) read `package/src/`. Do not touch
+              `package/CHANGELOG.md`, the manifest, or the release config.
+            - Match the existing prose style. Do not use em dashes.
+            - Keep changelog bullets factual and short. No marketing language.
+            - If something is ambiguous, leave a clear `{/* TODO: ... */}`
+              MDX comment in the page rather than guessing.
+
+            ## Final output
+            After making edits, write a summary to
+            `.release-context/agent-summary.md` containing:
+              - Pages updated (with one-line reason each)
+              - New pages created
+              - Pages flagged for human review (and why)
+              - Any exports you couldn't map to a page
+
+      - name: Commit and push docs updates
+        id: commit
+        env:
+          DOCS_BRANCH: ${{ steps.ctx.outputs.docs_branch }}
+          NEXT_VERSION: ${{ steps.ctx.outputs.next_version }}
+        run: |
+          set -euo pipefail
+          # Strip the throwaway context dir before committing.
+          rm -rf .release-context
+          git add docs/content/docs
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "docs: update for v$NEXT_VERSION"
+          git push --force-with-lease origin "$DOCS_BRANCH"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update docs PR
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCS_BRANCH: ${{ steps.ctx.outputs.docs_branch }}
+          NEXT_VERSION: ${{ steps.ctx.outputs.next_version }}
+          RELEASE_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh pr list --head "$DOCS_BRANCH" --base main --state open --json number --jq '.[0].number' || true)
+          BODY=$(printf "Generated docs updates for the upcoming v%s release.\n\nPaired with #%s. Review and merge after the release lands.\n\nThis PR is regenerated automatically every time the release-please PR is updated. Manual edits on this branch will be overwritten." "$NEXT_VERSION" "$RELEASE_PR_NUMBER")
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "docs: update for v$NEXT_VERSION" --body "$BODY"
+          else
+            gh pr create \
+              --base main \
+              --head "$DOCS_BRANCH" \
+              --title "docs: update for v$NEXT_VERSION" \
+              --body "$BODY"
+          fi

--- a/docs/app/[[...slug]]/page.tsx
+++ b/docs/app/[[...slug]]/page.tsx
@@ -8,7 +8,8 @@ import {
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { getMDXComponents } from '@/mdx-components';
-import { LLMCopyButton, ViewOptions } from '@/components/page-actions';
+import { LLMCopyButton, ViewOptions, ViewSourceButton } from '@/components/page-actions';
+import { PageChangelog, type ChangelogEntry } from '@/components/PageChangelog';
 import type React from 'react';
 import type { MDXComponents } from 'mdx/types';
 
@@ -18,6 +19,8 @@ type PageDataWithBody = {
   full: boolean;
   title: string;
   description?: string;
+  source?: string | string[];
+  changelog?: ChangelogEntry[];
   getText: (type: 'processed' | 'raw') => Promise<string>;
 };
 
@@ -39,6 +42,7 @@ export default async function Page(props: {
           markdownUrl={`${page.url}.mdx`}
           githubUrl={`https://github.com/pipecat-ai/voice-ui-kit/blob/main/docs/content/docs/${page.path}`}
         />
+        {pageData.source && <ViewSourceButton sources={pageData.source} />}
       </div>
       <DocsTitle>{pageData.title}</DocsTitle>
       <DocsDescription>{pageData.description}</DocsDescription>
@@ -49,6 +53,7 @@ export default async function Page(props: {
             a: createRelativeLink(source, page),
           })}
         />
+        <PageChangelog entries={pageData.changelog} />
       </DocsBody>
     </DocsPage>
   );

--- a/docs/components/PageChangelog.tsx
+++ b/docs/components/PageChangelog.tsx
@@ -1,0 +1,81 @@
+import { Fragment, type ReactNode } from "react";
+import { cn } from "../lib/cn";
+
+export type ChangelogEntry = {
+  version: string;
+  date?: string;
+  changes: string[];
+};
+
+// Renders inline backtick code spans. Anything between matched backticks
+// becomes <code>; everything else is plain text. We deliberately keep this
+// narrow rather than pulling in a full markdown renderer.
+function renderInline(text: string): ReactNode {
+  const parts = text.split(/(`[^`]+`)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`") && part.length > 2) {
+      return (
+        <code
+          key={i}
+          className="rounded bg-fd-muted px-1 py-0.5 font-mono text-[0.85em] text-fd-foreground"
+        >
+          {part.slice(1, -1)}
+        </code>
+      );
+    }
+    return <Fragment key={i}>{part}</Fragment>;
+  });
+}
+
+export function PageChangelog({
+  entries,
+  className,
+}: {
+  entries?: ChangelogEntry[];
+  className?: string;
+}) {
+  if (!entries || entries.length === 0) return null;
+
+  return (
+    <section
+      className={cn("mt-10 border-t border-fd-border pt-5", className)}
+      aria-labelledby="page-changelog"
+    >
+      <h2
+        id="page-changelog"
+        className="mb-3 text-base font-semibold text-fd-foreground"
+      >
+        Changelog
+      </h2>
+      <dl className="space-y-1.5 text-sm">
+        {entries.map((entry) => (
+          <div
+            key={entry.version}
+            className="grid gap-x-4 sm:grid-cols-[8rem_1fr]"
+          >
+            <dt className="flex flex-col leading-tight sm:pt-0.5">
+              <span className="font-mono text-sm text-fd-foreground">
+                {entry.version}
+              </span>
+              {entry.date && (
+                <time
+                  dateTime={entry.date}
+                  className="text-xs text-fd-muted-foreground"
+                >
+                  {entry.date}
+                </time>
+              )}
+            </dt>
+            <dd className="text-fd-foreground/90">
+              <ul className="list-disc pl-5 marker:text-fd-muted-foreground/60">
+                {entry.changes.map((change, idx) => (
+                  <li key={idx}>{renderInline(change)}</li>
+                ))}
+              </ul>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -1,11 +1,73 @@
 'use client';
 import { useMemo, useState } from 'react';
-import { Check, ChevronDown, Copy, ExternalLinkIcon, MessageCircleIcon } from 'lucide-react';
+import { Check, ChevronDown, CodeIcon, Copy, ExternalLinkIcon, MessageCircleIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { useCopyButton } from 'fumadocs-ui/utils/use-copy-button';
 import { buttonVariants } from './ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { cva } from 'class-variance-authority';
+
+const REPO_BLOB_BASE = 'https://github.com/pipecat-ai/voice-ui-kit/blob/main/';
+
+export function ViewSourceButton({
+  sources,
+}: {
+  /**
+   * Repo-relative path(s) to the implementation source. A single string renders
+   * a direct link; multiple paths render a popover menu.
+   */
+  sources: string | string[];
+}) {
+  const list = Array.isArray(sources) ? sources : [sources];
+  if (list.length === 0) return null;
+
+  const buttonClass = cn(
+    buttonVariants({
+      color: 'secondary',
+      size: 'sm',
+      className: 'gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground',
+    }),
+  );
+
+  if (list.length === 1) {
+    return (
+      <a
+        href={`${REPO_BLOB_BASE}${list[0]}`}
+        rel="noreferrer noopener"
+        target="_blank"
+        className={buttonClass}
+      >
+        <CodeIcon />
+        View source
+      </a>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger className={buttonClass}>
+        <CodeIcon />
+        View source
+        <ChevronDown className="size-3.5 text-fd-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent className="flex flex-col">
+        {list.map((path) => (
+          <a
+            key={path}
+            href={`${REPO_BLOB_BASE}${path}`}
+            rel="noreferrer noopener"
+            target="_blank"
+            className="text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4"
+          >
+            <CodeIcon />
+            <span className="font-mono text-xs">{path}</span>
+            <ExternalLinkIcon className="text-fd-muted-foreground size-3.5 ms-auto" />
+          </a>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 const cache = new Map<string, string>();
 

--- a/docs/content/docs/components/BotAudioControl.mdx
+++ b/docs/content/docs/components/BotAudioControl.mdx
@@ -2,6 +2,13 @@
 title: Bot Audio Control
 description: Control for adjusting the bot's audio output volume
 component: BotAudioControl
+source: package/src/components/elements/BotAudioControl.tsx
+changelog:
+  - version: "v0.9.0"
+    date: "2026-04-24"
+    changes:
+      - "Added. Renders a button with a popover-mounted volume slider for the bot's audio output."
+      - "Stays in sync with other `BotAudioControl`, `BotVolumeSlider`, and `useBotAudioOutput` consumers via the shared bot audio store."
 ---
 
 The `BotAudioControl` component provides a button with a popover-mounted volume slider for controlling the bot's audio output level. It integrates with the kit's bot audio store so any number of instances stay in sync, and it drives the `<audio>` element rendered by `BotAudioOutput` (used automatically by `PipecatAppBase`).

--- a/docs/content/docs/components/BotVolumeSlider.mdx
+++ b/docs/content/docs/components/BotVolumeSlider.mdx
@@ -2,6 +2,12 @@
 title: Bot Volume Slider
 description: Inline slider for controlling the bot's audio output volume
 component: BotVolumeSlider
+source: package/src/components/elements/BotVolumeSlider.tsx
+changelog:
+  - version: "v0.9.0"
+    date: "2026-04-24"
+    changes:
+      - "Added. Inline volume slider for the bot's audio output, extracted from `BotAudioControl` for standalone use."
 ---
 
 The `BotVolumeSlider` component is an inline volume slider for the bot's audio output. It is the same slider that lives inside [`BotAudioControl`](/components/BotAudioControl)'s popover, extracted so you can embed it standalone — for example in a settings panel, a sidebar, or a custom toolbar.

--- a/docs/content/docs/components/ClientStatus.mdx
+++ b/docs/content/docs/components/ClientStatus.mdx
@@ -2,6 +2,7 @@
 title: Client Status
 description: Displays client and agent connection status
 component: ClientStatus
+source: package/src/components/elements/ClientStatus.tsx
 ---
 
 The ClientStatus component displays the connection status of both the client and agent (bot) in a structured data list format. It automatically integrates with the Pipecat Client SDK to show real-time connection states.

--- a/docs/content/docs/components/ConnectButton.mdx
+++ b/docs/content/docs/components/ConnectButton.mdx
@@ -2,6 +2,12 @@
 title: Connect Button
 description: Button component that adapts to connection state for connecting/disconnecting sessions
 component: ConnectButton
+source: package/src/components/elements/ConnectButton.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "`Console` template now renders a tooltip on the Connect button showing the connection endpoint."
 ---
 
 The ConnectButton component provides a button that automatically adapts its appearance and behavior based on the current transport connection state. It handles connect and disconnect actions automatically and supports custom state content configuration.

--- a/docs/content/docs/components/Conversation.mdx
+++ b/docs/content/docs/components/Conversation.mdx
@@ -2,6 +2,52 @@
 title: Conversation
 description: Real-time conversation display component with message history and text input
 component: Conversation
+source: package/src/components/elements/Conversation.tsx
+changelog:
+  - version: "v0.9.0"
+    date: "2026-04-24"
+    changes:
+      - "Added `textRenderMode` switch for bot message display."
+  - version: "v0.8.2"
+    date: "2026-03-31"
+    changes:
+      - "Backdate injected messages during an active bot response so karaoke ordering stays stable."
+      - "Backdate mid-turn function calls to preserve the karaoke cursor."
+      - "Karaoke highlighting now handles non-ASCII text and punctuation correctly."
+  - version: "v0.8.1"
+    date: "2026-03-11"
+    changes:
+      - "Optimized the conversation rendering pipeline."
+      - "Improved turn detection and karaoke highlighting."
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added `reverseOrder` prop."
+      - "Added function-call rendering: `noFunctionCalls`, `functionCallLabel`, and `functionCallRenderer` props."
+      - "`ConversationMessage.role` now includes `function_call`."
+  - version: "v0.7.2"
+    date: "2026-02-23"
+    changes:
+      - "Fixed long bot messages getting truncated when the bot stopped speaking mid-turn."
+  - version: "v0.7.0"
+    date: "2026-02-05"
+    changes:
+      - "Added `botOutputRenderers` prop to customize rendering by aggregation type."
+      - "`Conversation` building now uses `BotOutput` events when the server supports them; a warning is shown otherwise."
+  - version: "v0.6.0"
+    date: "2025-12-15"
+    changes:
+      - "Added `noTextInput` prop to hide text input controls."
+  - version: "v0.4.0"
+    date: "2025-10-02"
+    changes:
+      - "Fixed component layout in some configurations."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Restructured conversation message types to introduce parts for better transcription handling."
+      - "Added programmatic message injection via `injectMessage`."
+      - "Message rendering now supports both string content and React components."
 ---
 
 The Conversation component displays real-time conversation history between users and AI assistants. It automatically integrates with the Pipecat Client SDK to show messages, connection states, and provides smooth scrolling behavior.

--- a/docs/content/docs/components/DeviceDropDown.mdx
+++ b/docs/content/docs/components/DeviceDropDown.mdx
@@ -2,6 +2,12 @@
 title: Device Drop Down
 description: Dropdown menu for microphone / audio input device selection
 component: DeviceDropDown
+source: package/src/components/elements/DeviceDropDown.tsx
+changelog:
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "`UserAudioControl` and `UserVideoControl` now accept `deviceDropDownProps` for configuring the underlying dropdown."
 ---
 
 The `DeviceDropDown` component provides a dropdown menu interface for selecting and managing microphone input devices in your voice application. 

--- a/docs/content/docs/components/DeviceSelect.mdx
+++ b/docs/content/docs/components/DeviceSelect.mdx
@@ -2,6 +2,12 @@
 title: Device Select
 description: Microphone / audio input selection component
 component: DeviceSelect
+source: package/src/components/elements/DeviceSelect.tsx
+changelog:
+  - version: "v0.2.1"
+    date: "2025-08-20"
+    changes:
+      - "Added. Renders available devices in a select control."
 ---
 
 The DeviceSelect component provides a user interface for selecting and managing microphone input devices in your voice application. It integrates with the Pipecat Client SDK to automatically detect available microphones and allow users to switch between them.

--- a/docs/content/docs/components/FunctionCallContent.mdx
+++ b/docs/content/docs/components/FunctionCallContent.mdx
@@ -2,6 +2,14 @@
 title: Function Call Content
 description: Component for displaying LLM function calls with collapsible details
 component: FunctionCallContent
+source: package/src/components/elements/FunctionCallContent.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added. Renders LLM function calls with collapsible details for arguments and result."
+      - "Shows a friendly label for unnamed function calls."
+      - "Accepts `functionCallRenderer` for custom rendering."
 ---
 
 The FunctionCallContent component renders LLM function call entries in the conversation. It displays the function name and status, with arguments and results collapsed by default using a collapsible UI.

--- a/docs/content/docs/components/MessageContainer.mdx
+++ b/docs/content/docs/components/MessageContainer.mdx
@@ -2,6 +2,12 @@
 title: Message Container
 description: Container component for individual conversation messages
 component: MessageContainer
+source: package/src/components/elements/MessageContainer.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added `functionCallLabel` and `functionCallRenderer` props."
 ---
 
 The MessageContainer component wraps individual conversation messages, displaying the message role and content in a structured format. It's typically used within the Conversation component to render each message in the conversation history.

--- a/docs/content/docs/components/MessageContent.mdx
+++ b/docs/content/docs/components/MessageContent.mdx
@@ -2,6 +2,21 @@
 title: Message Content
 description: Component for displaying the content of conversation messages
 component: MessageContent
+source: package/src/components/elements/MessageContent.tsx
+changelog:
+  - version: "v0.8.2"
+    date: "2026-03-31"
+    changes:
+      - "Karaoke highlighting now handles non-ASCII text and punctuation."
+  - version: "v0.8.1"
+    date: "2026-03-11"
+    changes:
+      - "Improved turn detection and karaoke highlighting."
+      - "Performance improvements as part of the conversation rendering pipeline optimization."
+  - version: "v0.7.0"
+    date: "2026-02-05"
+    changes:
+      - "Added `botOutputRenderers` prop and `aggregationMetadata` to control rendering and speech progress per aggregation type."
 ---
 
 The MessageContent component renders the actual content of a conversation message, including text parts, thinking indicators, and timestamps. It handles multiple text parts and automatically shows a thinking indicator for empty messages.

--- a/docs/content/docs/components/MessageRole.mdx
+++ b/docs/content/docs/components/MessageRole.mdx
@@ -2,6 +2,12 @@
 title: Message Role
 description: Component for displaying message role labels
 component: MessageRole
+source: package/src/components/elements/MessageRole.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added `functionCallLabel` prop to customize the label shown for function-call messages."
 ---
 
 The MessageRole component displays the role label for a conversation message (user, assistant, system, or function_call). It uses color-coded styling to distinguish between different roles and supports custom labels.

--- a/docs/content/docs/components/PipecatAppBase.mdx
+++ b/docs/content/docs/components/PipecatAppBase.mdx
@@ -2,6 +2,34 @@
 title: Pipecat App Base
 description: Higher-order component that streamlines setup of a Pipecat Client instance
 component: PipecatAppBase
+source: package/src/components/PipecatAppBase.tsx
+changelog:
+  - version: "v0.8.2"
+    date: "2026-03-31"
+    changes:
+      - "Use `startBotAndConnect` when `connectParams` is an `APIRequest`."
+  - version: "v0.5.0"
+    date: "2025-11-07"
+    changes:
+      - "Added `initDevicesOnMount` prop, giving control over when device-access permissions are requested."
+  - version: "v0.4.0"
+    date: "2025-10-02"
+    changes:
+      - "Updated for the latest Pipecat Client API."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Fixed memoization regressions."
+      - "Now accepts a partial `clientOptions` object."
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Renamed from `AudioClientHelper`."
+      - "Now accepts both React node children and a render-prop list for prop injection."
+      - "Added `noThemeProvider` prop to disable the wrapping `ThemeProvider`."
+      - "Connection handlers `handleConnect` and `handleDisconnect` now accept sync or async functions."
+      - "Returns the client object via child props."
+      - "Fixed TypeScript component type to resolve JSX usage errors."
 ---
 
 The `PipecatAppBase` component reduces the boilerplate code required to bootstrap a new Pipecat Client application.

--- a/docs/content/docs/components/SessionInfo.mdx
+++ b/docs/content/docs/components/SessionInfo.mdx
@@ -2,6 +2,17 @@
 title: Session Info
 description: Component for displaying session information including transport type, session ID, and participant ID
 component: SessionInfo
+source: package/src/components/elements/SessionInfo.tsx
+changelog:
+  - version: "v0.7.0"
+    date: "2026-02-05"
+    changes:
+      - "Now displays the RTVI Server version (from `BotReady`)."
+      - "Added `noRTVIVersion` prop to hide the RTVI version section."
+  - version: "v0.4.0"
+    date: "2025-10-02"
+    changes:
+      - "Now shows the session ID from the transport."
 ---
 
 The SessionInfo component displays session-related information in a structured format, including transport type, session ID, participant ID, and RTVI version. It automatically integrates with the Pipecat Client SDK to fetch this information.

--- a/docs/content/docs/components/TextInput.mdx
+++ b/docs/content/docs/components/TextInput.mdx
@@ -2,6 +2,17 @@
 title: Text Input
 description: Text input component for sending text messages to the bot
 component: TextInput
+source: package/src/components/elements/TextInput.tsx
+changelog:
+  - version: "v0.6.0"
+    date: "2025-12-15"
+    changes:
+      - "Added `noInject` prop to prevent user text messages from being injected into conversation state."
+      - "Added `onSend` callback prop."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Added. Component for sending text messages from the UI."
 ---
 
 The TextInput component provides a user interface for entering and sending textual messages to the bot. It includes both a headless variant for full control and a connected variant that automatically integrates with the Pipecat Client SDK.

--- a/docs/content/docs/components/Thinking.mdx
+++ b/docs/content/docs/components/Thinking.mdx
@@ -2,6 +2,7 @@
 title: Thinking
 description: Animated thinking/loading indicator component
 component: Thinking
+source: package/src/components/elements/Thinking.tsx
 ---
 
 The Thinking component displays an animated thinking indicator using dots. It's commonly used to show that the system is processing or waiting for a response.

--- a/docs/content/docs/components/TranscriptOverlay.mdx
+++ b/docs/content/docs/components/TranscriptOverlay.mdx
@@ -2,6 +2,16 @@
 title: Transcript Overlay
 description: Real-time speech transcript display component with smooth animations
 component: TranscriptOverlay
+source: package/src/components/elements/TranscriptOverlay.tsx
+changelog:
+  - version: "v0.7.0"
+    date: "2026-02-05"
+    changes:
+      - "Now uses `BotOutput` events for the remote participant when supported (word-level), and falls back gracefully on servers that send sentence-level or non-word-level TTS."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Animation durations are now configurable via props."
 ---
 
 The `TranscriptOverlay` component displays real-time speech transcripts as an animated overlay. It automatically listens to Pipecat Client events to show speech transcripts from either the local user or remote bot, with smooth fade-in and fade-out animations.

--- a/docs/content/docs/components/UserAudioControl.mdx
+++ b/docs/content/docs/components/UserAudioControl.mdx
@@ -2,6 +2,25 @@
 title: User Audio Control
 description: Microphone control component with device selection and visualizer
 component: UserAudioControl
+source: package/src/components/elements/UserAudioControl.tsx
+changelog:
+  - version: "v0.6.0"
+    date: "2025-12-15"
+    changes:
+      - "Dropdown can now list both microphones and speakers with grouped sections."
+      - "Added `dropdownMenuLabel`, `microphoneLabel`, and `speakerLabel` props."
+      - "Added `noMicrophones` and `noSpeakers` props to independently hide dropdown sections."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Now accepts `deviceDropDownProps` for configuring the underlying dropdown."
+      - "Visualizer color now uses `currentColor` instead of resolving from a CSS variable."
+  - version: "v0.2.1"
+    date: "2025-08-20"
+    changes:
+      - "Added `activeText` and `inactiveText` props for simpler mute buttons."
+      - "Added `noIcon` prop to hide the mic icon."
+      - "Now accepts children for further flexibility."
 ---
 
 The `UserAudioControl` component provides a comprehensive microphone control interface that includes microphone toggle functionality, device selection, and optional audio visualization. It integrates with the Pipecat Client SDK to automatically manage microphone state and device selection.

--- a/docs/content/docs/components/UserAudioOutputControl.mdx
+++ b/docs/content/docs/components/UserAudioOutputControl.mdx
@@ -2,6 +2,16 @@
 title: User Audio Output Control
 description: Speaker device selection component for user audio output
 component: UserAudioOutputControl
+source: package/src/components/elements/UserAudioOutputControl.tsx
+changelog:
+  - version: "v0.6.0"
+    date: "2025-12-15"
+    changes:
+      - "`Console` template now uses `UserAudioControl` for speaker selection instead of `UserAudioOutputControl`."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Renamed from `AudioOutput` for naming consistency."
 ---
 
 The UserAudioOutputControl component provides a user interface for selecting and managing audio output devices in your voice application. When using the connected variant, it integrates with the Pipecat Client SDK to automatically detect available speakers and allow users to switch between them.

--- a/docs/content/docs/components/UserScreenControl.mdx
+++ b/docs/content/docs/components/UserScreenControl.mdx
@@ -2,6 +2,12 @@
 title: User Screen Control
 description: Component for controlling screen sharing with visual preview
 component: UserScreenControl
+source: package/src/components/elements/UserScreenControl.tsx
+changelog:
+  - version: "v0.4.1"
+    date: "2025-10-14"
+    changes:
+      - "Added. Manages screen-share media. `UserScreenControlComponent` is also exported."
 ---
 
 The UserScreenControl component provides a user interface for controlling screen sharing. It displays a preview of the shared screen and a toggle button to start/stop screen sharing. It automatically integrates with the Pipecat Client SDK.

--- a/docs/content/docs/components/UserVideoControl.mdx
+++ b/docs/content/docs/components/UserVideoControl.mdx
@@ -2,6 +2,12 @@
 title: User Video Control
 description: Camera control component with device selection and video preview
 component: UserVideoControl
+source: package/src/components/elements/UserVideoControl.tsx
+changelog:
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Now accepts `deviceDropDownProps` for configuring the underlying dropdown."
 ---
 
 The `UserVideoControl` component provides a comprehensive camera control interface that includes camera toggle functionality, device selection, and optional video preview. It integrates with the Pipecat Client SDK to automatically manage camera state and device selection.

--- a/docs/content/docs/hooks/useBotAudioOutput.mdx
+++ b/docs/content/docs/hooks/useBotAudioOutput.mdx
@@ -1,6 +1,12 @@
 ---
 title: useBotAudioOutput
 description: Hook for reading and updating the bot's audio output volume
+source: package/src/hooks/useBotAudioOutput.ts
+changelog:
+  - version: "v0.9.0"
+    date: "2026-04-24"
+    changes:
+      - "Added. Reads and updates the bot's audio output volume from the shared bot audio store."
 ---
 
 The `useBotAudioOutput` hook exposes the bot audio output state that drives the `<audio>` element rendered by `BotAudioOutput`. Use it to read the current volume or to set it from anywhere in your app — the `BotAudioControl` component and any other consumer stay in sync automatically.

--- a/docs/content/docs/hooks/usePipecatConnectionState.mdx
+++ b/docs/content/docs/hooks/usePipecatConnectionState.mdx
@@ -1,6 +1,16 @@
 ---
 title: usePipecatConnectionState
 description: Hook that provides a simplified connection state for Pipecat transport.
+source: package/src/hooks/usePipecatConnectionState.ts
+changelog:
+  - version: "v0.4.1"
+    date: "2025-10-14"
+    changes:
+      - "Fixed bug where state would not update if the component was conditionally rendered after the client connected."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Now returns boolean helpers `isConnected`, `isConnecting`, and `isDisconnected` alongside the state."
 ---
 
 ## Overview

--- a/docs/content/docs/hooks/usePipecatConversation.mdx
+++ b/docs/content/docs/hooks/usePipecatConversation.mdx
@@ -1,6 +1,14 @@
 ---
 title: usePipecatConversation
 description: Hook that derives a clean, ordered conversation stream from RTVI events.
+source:
+  - package/src/hooks/usePipecatConversation.ts
+  - package/src/components/ConversationProvider.tsx
+changelog:
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Added. Derives a clean, ordered conversation stream from RTVI events for chat-style transcripts."
 ---
 
 ## Overview

--- a/docs/content/docs/hooks/usePipecatEventStream.mdx
+++ b/docs/content/docs/hooks/usePipecatEventStream.mdx
@@ -1,6 +1,12 @@
 ---
 title: usePipecatEventStream
 description: Hook to subscribe to Pipecat RTVI events with throttled updates and optional grouping.
+source: package/src/hooks/usePipecatEventStream.ts
+changelog:
+  - version: "v0.2.1"
+    date: "2025-08-20"
+    changes:
+      - "Added. Exposes a firehose of events from the Pipecat client."
 ---
 
 ## Overview

--- a/docs/content/docs/hooks/useTheme.mdx
+++ b/docs/content/docs/hooks/useTheme.mdx
@@ -1,6 +1,13 @@
 ---
 title: useTheme
 description: Hook for accessing and managing theme state
+source: package/src/hooks/useTheme.ts
+changelog:
+  - version: "v0.2.1"
+    date: "2025-08-20"
+    changes:
+      - "Added. Reads and sets the active theme when wrapped in `ThemeProvider`."
+      - "`ThemeProvider` context now supports arbitrary theme names."
 ---
 
 The `useTheme` hook provides access to the theme context, allowing you to read and update the current theme. It must be used within a `ThemeProvider` component.

--- a/docs/content/docs/panels/BotAudioPanel.mdx
+++ b/docs/content/docs/panels/BotAudioPanel.mdx
@@ -2,6 +2,14 @@
 title: Bot Audio Panel
 description: Panel component for displaying bot audio visualization
 component: BotAudioPanel
+source: package/src/components/panels/BotAudioPanel.tsx
+changelog:
+  - version: "v0.9.0"
+    date: "2026-04-24"
+    changes:
+      - "Added bot audio output volume control to the panel."
+      - "Center panel title when controls are hidden, align popover end."
+      - "Removed reserved-mute prop comments."
 ---
 
 The BotAudioPanel component displays a visual representation of the bot's audio output using a waveform visualizer. It automatically integrates with the Pipecat Client SDK to show real-time audio visualization.

--- a/docs/content/docs/panels/BotVideoPanel.mdx
+++ b/docs/content/docs/panels/BotVideoPanel.mdx
@@ -2,6 +2,7 @@
 title: Bot Video Panel
 description: Panel component for displaying bot video feed
 component: BotVideoPanel
+source: package/src/components/panels/BotVideoPanel.tsx
 ---
 
 The BotVideoPanel component displays the bot's video feed in a panel. It automatically integrates with the Pipecat Client SDK to show real-time video output.

--- a/docs/content/docs/panels/ConversationPanel.mdx
+++ b/docs/content/docs/panels/ConversationPanel.mdx
@@ -2,6 +2,21 @@
 title: Conversation Panel
 description: Panel component with tabs for conversation and metrics
 component: ConversationPanel
+source: package/src/components/panels/ConversationPanel.tsx
+changelog:
+  - version: "v0.9.0"
+    date: "2026-04-24"
+    changes:
+      - "Inherits the new `textRenderMode` switch for bot message display from `Conversation`."
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added rendering of LLM function-call entries in the panel."
+      - "Added `noFunctionCalls` prop to disable function-call rendering."
+  - version: "v0.7.0"
+    date: "2026-02-05"
+    changes:
+      - "Added `botOutputRenderers` prop."
 ---
 
 The ConversationPanel component provides a tabbed interface combining conversation display and metrics. It includes a conversation tab for message history and a metrics tab for performance data.

--- a/docs/content/docs/panels/EventsPanel.mdx
+++ b/docs/content/docs/panels/EventsPanel.mdx
@@ -2,6 +2,7 @@
 title: Events Panel
 description: Panel component for displaying RTVI events and logs
 component: EventsPanel
+source: package/src/components/panels/EventsPanel.tsx
 ---
 
 The EventsPanel component displays a real-time log of RTVI events from the Pipecat Client SDK. It shows connection events, bot events, track events, and more, with filtering capabilities.

--- a/docs/content/docs/panels/InfoPanel.mdx
+++ b/docs/content/docs/panels/InfoPanel.mdx
@@ -2,6 +2,12 @@
 title: Info Panel
 description: Panel component displaying status, devices, and session information
 component: InfoPanel
+source: package/src/components/panels/InfoPanel.tsx
+changelog:
+  - version: "v0.4.1"
+    date: "2025-10-14"
+    changes:
+      - "Now renders `UserScreenControl` when supported by the transport."
 ---
 
 The InfoPanel component provides a comprehensive information panel that displays connection status, device controls, and session information. It combines multiple components into a single organized panel.

--- a/docs/content/docs/primitives/badge.mdx
+++ b/docs/content/docs/primitives/badge.mdx
@@ -2,6 +2,12 @@
 title: Badge
 description: Displays a badge or a component that looks like a badge.
 component: Badge
+source: package/src/components/ui/badge.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added `Badge` primitive."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/banner.mdx
+++ b/docs/content/docs/primitives/banner.mdx
@@ -2,6 +2,7 @@
 title: Banner
 description: Inline notification banner with actions.
 component: Banner
+source: package/src/components/ui/banner.tsx
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/blankslates.mdx
+++ b/docs/content/docs/primitives/blankslates.mdx
@@ -2,6 +2,7 @@
 title: Blankslates
 description: Empty state components for displaying placeholder content
 component: TextDashBlankslate
+source: package/src/components/ui/blankslates.tsx
 ---
 
 Blankslates are components used to display empty or placeholder states. The Voice UI Kit provides a simple text-based blankslate component.

--- a/docs/content/docs/primitives/button.mdx
+++ b/docs/content/docs/primitives/button.mdx
@@ -2,6 +2,14 @@
 title: Button
 description: Displays a button or a component that looks like a button.
 component: Button
+source:
+  - package/src/components/ui/button.tsx
+  - package/src/components/ui/buttonVariants.ts
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added TW4 utilities for button sizing."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/buttongroup.mdx
+++ b/docs/content/docs/primitives/buttongroup.mdx
@@ -2,6 +2,12 @@
 title: Button Group
 description: Group buttons together with shared borders and rounded logic.
 component: ButtonGroup
+source: package/src/components/ui/buttongroup.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Fixed border overlap for button groups in dark mode."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/card.mdx
+++ b/docs/content/docs/primitives/card.mdx
@@ -2,6 +2,13 @@
 title: Card
 description: Displays a card with optional header, content and footer.
 component: Card
+source: package/src/components/ui/card.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added additional card variants and decorations."
+      - "`Cards` no longer pad based on media queries, for layout flexibility."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/collapsible.mdx
+++ b/docs/content/docs/primitives/collapsible.mdx
@@ -1,6 +1,12 @@
 ---
 title: Collapsible
 description: Expandable/collapsible content sections.
+source: package/src/components/ui/collapsible.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added. Wraps @radix-ui/react-collapsible. Exports `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent`."
 ---
 
 A wrapper around `@radix-ui/react-collapsible` that provides expand/collapse functionality. Used internally by the `FunctionCallContent` component.

--- a/docs/content/docs/primitives/container.mdx
+++ b/docs/content/docs/primitives/container.mdx
@@ -2,6 +2,7 @@
 title: Container
 description: Full-screen container component for layout
 component: FullScreenContainer
+source: package/src/components/ui/container.tsx
 ---
 
 The Container component provides a full-screen container that fills the viewport height and centers its content. It's useful for creating full-page layouts or centered content areas.

--- a/docs/content/docs/primitives/control-bar.mdx
+++ b/docs/content/docs/primitives/control-bar.mdx
@@ -2,6 +2,7 @@
 title: Control Bar
 description: Container component for control elements with gradient border and animations
 component: ControlBar
+source: package/src/components/elements/ControlBar.tsx
 ---
 
 The ControlBar component provides a styled container for organizing control elements like buttons, toggles, and other interactive components. It features a gradient border, shadow effects, and optional entrance animations.

--- a/docs/content/docs/primitives/copy-text.mdx
+++ b/docs/content/docs/primitives/copy-text.mdx
@@ -2,6 +2,7 @@
 title: Copy Text
 description: Component for copying text to clipboard with visual feedback
 component: CopyText
+source: package/src/components/elements/CopyText.tsx
 ---
 
 The CopyText component provides a convenient way to copy text to the clipboard with a built-in copy button and visual feedback. It displays the text with a copy icon that changes to a checkmark when the text is successfully copied.

--- a/docs/content/docs/primitives/data-list.mdx
+++ b/docs/content/docs/primitives/data-list.mdx
@@ -2,6 +2,7 @@
 title: Data List
 description: Component for displaying key-value pairs in a structured list format
 component: DataList
+source: package/src/components/elements/DataList.tsx
 ---
 
 The DataList component displays data as a structured list of key-value pairs. It's useful for showing metadata, status information, or any structured data in a clean, readable format.

--- a/docs/content/docs/primitives/divider.mdx
+++ b/docs/content/docs/primitives/divider.mdx
@@ -2,6 +2,12 @@
 title: Divider
 description: Visual separator for content with support for orientation, variants, thickness, colors and decorations.
 component: Divider
+source: package/src/components/ui/divider.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added `Divider` primitive."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/dropdown-menu.mdx
+++ b/docs/content/docs/primitives/dropdown-menu.mdx
@@ -2,6 +2,7 @@
 title: Dropdown Menu
 description: Accessible menu with items, labels, separators and submenus.
 component: DropdownMenu
+source: package/src/components/ui/dropdown-menu.tsx
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/error.mdx
+++ b/docs/content/docs/primitives/error.mdx
@@ -2,6 +2,7 @@
 title: Error Card
 description: A convenience card for displaying error messages.
 component: ErrorCard
+source: package/src/components/ui/error.tsx
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/highlight-overlay.mdx
+++ b/docs/content/docs/primitives/highlight-overlay.mdx
@@ -2,6 +2,12 @@
 title: Highlight Overlay
 description: Imperative overlay to highlight any DOM element via id or ref.
 component: HighlightOverlay
+source: package/src/components/elements/HighlightOverlay.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added. Draws user attention to a specific UI element."
 ---
 
 ## Overview

--- a/docs/content/docs/primitives/input.mdx
+++ b/docs/content/docs/primitives/input.mdx
@@ -2,6 +2,9 @@
 title: Input
 description: A text input field with variants and sizes.
 component: Input
+source:
+  - package/src/components/ui/input.tsx
+  - package/src/components/ui/inputVariants.ts
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/layout.mdx
+++ b/docs/content/docs/primitives/layout.mdx
@@ -2,6 +2,7 @@
 title: Layout
 description: Layout section component for semantic HTML structure
 component: LayoutSection
+source: package/src/components/ui/layout.tsx
 ---
 
 The Layout component provides a semantic section element with a data attribute for identification. It's useful for creating structured layouts and identifying sections programmatically.

--- a/docs/content/docs/primitives/led.mdx
+++ b/docs/content/docs/primitives/led.mdx
@@ -2,6 +2,12 @@
 title: LED
 description: Small on/off indicator with optional blinking or change-driven flash.
 component: LED
+source: package/src/components/ui/led.tsx
+changelog:
+  - version: "v0.2.1"
+    date: "2025-08-20"
+    changes:
+      - "Added. Binary `LED` indicator for visual feedback on a watched property."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/loader.mdx
+++ b/docs/content/docs/primitives/loader.mdx
@@ -2,6 +2,13 @@
 title: Loader
 description: Loading indicators for async states.
 component: Loader
+source: package/src/components/ui/loader.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added `StripeLoader`."
+      - "Renamed `LoaderSpinner` to `SpinLoader` to establish a naming convention for future loaders."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/panel.mdx
+++ b/docs/content/docs/primitives/panel.mdx
@@ -2,6 +2,7 @@
 title: Panel
 description: A simple panel layout with header, content, footer and actions.
 component: Panel
+source: package/src/components/ui/panel.tsx
 ---
 
 Dashboard panel that uses container queries to adjust its size.

--- a/docs/content/docs/primitives/pipecat-logo.mdx
+++ b/docs/content/docs/primitives/pipecat-logo.mdx
@@ -2,6 +2,7 @@
 title: Pipecat Logo
 description: SVG logo component for Pipecat branding
 component: PipecatLogo
+source: package/src/components/elements/PipecatLogo.tsx
 ---
 
 The PipecatLogo component renders the Pipecat logo as an SVG. It supports customizable size, color, and styling while maintaining the correct aspect ratio.

--- a/docs/content/docs/primitives/popover.mdx
+++ b/docs/content/docs/primitives/popover.mdx
@@ -2,6 +2,7 @@
 title: Popover
 description: Popover component built on Radix UI for displaying floating content
 component: Popover
+source: package/src/components/ui/popover.tsx
 ---
 
 The Popover component provides a floating content panel that appears above other content. It's built on Radix UI and includes proper portal rendering and animations.

--- a/docs/content/docs/primitives/progress.mdx
+++ b/docs/content/docs/primitives/progress.mdx
@@ -2,6 +2,12 @@
 title: Progress
 description: A lightweight progress bar with semantic colors and sizes.
 component: Progress
+source: package/src/components/ui/progress.tsx
+changelog:
+  - version: "v0.2.0"
+    date: "2025-08-16"
+    changes:
+      - "Added `Progress` primitive."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/resizable.mdx
+++ b/docs/content/docs/primitives/resizable.mdx
@@ -2,6 +2,7 @@
 title: Resizable
 description: Resizable panel components for creating adjustable layouts
 component: ResizablePanelGroup
+source: package/src/components/ui/resizable.tsx
 ---
 
 The Resizable components provide a way to create adjustable panel layouts where users can resize panels by dragging. Built on react-resizable-panels, these components support both horizontal and vertical layouts.

--- a/docs/content/docs/primitives/select.mdx
+++ b/docs/content/docs/primitives/select.mdx
@@ -2,6 +2,12 @@
 title: Select
 description: Accessible select component built on Radix Select.
 component: Select
+source: package/src/components/ui/select.tsx
+changelog:
+  - version: "v0.2.1"
+    date: "2025-08-20"
+    changes:
+      - "`SelectTrigger` now supports an alignment variant prop."
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/tabs.mdx
+++ b/docs/content/docs/primitives/tabs.mdx
@@ -2,6 +2,7 @@
 title: Tabs
 description: Tabbed interface built on Radix Tabs.
 component: Tabs
+source: package/src/components/ui/tabs.tsx
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/primitives/textarea.mdx
+++ b/docs/content/docs/primitives/textarea.mdx
@@ -2,6 +2,12 @@
 title: Textarea
 description: Multi-line text input component
 component: Textarea
+source: package/src/components/ui/textarea.tsx
+changelog:
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Fixed `Textarea` sizing and auto-height."
 ---
 
 The Textarea component provides a multi-line text input field. It extends the standard HTML textarea element with Voice UI Kit styling and variants.

--- a/docs/content/docs/primitives/tooltip.mdx
+++ b/docs/content/docs/primitives/tooltip.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tooltip
 description: Small, contextual information on hover/focus.
+source: package/src/components/ui/tooltip.tsx
 ---
 
 <LiveComponent language="tsx">

--- a/docs/content/docs/templates/console.mdx
+++ b/docs/content/docs/templates/console.mdx
@@ -2,6 +2,28 @@
 title: Console Template
 description: Full-featured console interface template for Pipecat applications
 component: ConsoleTemplate
+source:
+  - package/src/templates/Console/index.tsx
+  - package/src/templates/Console/SmallWebRTCCodecSetter.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Added a tooltip on the Connect button showing the connection endpoint."
+  - version: "v0.6.0"
+    date: "2025-12-15"
+    changes:
+      - "Now uses `UserAudioControl` for speaker selection instead of `UserAudioOutputControl`."
+      - "Added `noTextInput` prop to hide text input controls."
+      - "Fixed `noAudioOutput` being correctly passed down to `PipecatAppBase`."
+  - version: "v0.4.1"
+    date: "2025-10-14"
+    changes:
+      - "Added `UserScreenControl` integration when supported."
+  - version: "v0.4.0"
+    date: "2025-10-02"
+    changes:
+      - "Now shows session ID from the transport."
 ---
 
 The Console template provides a complete, production-ready interface for Pipecat applications. It includes resizable panels, conversation display, bot media visualization, device controls, event logging, and more.

--- a/docs/content/docs/templates/widget.mdx
+++ b/docs/content/docs/templates/widget.mdx
@@ -2,6 +2,7 @@
 title: Widget Template
 description: Compact widget template for embedding Pipecat functionality
 component: WidgetTemplate
+source: package/src/templates/Widget/index.tsx
 ---
 
 The Widget template provides a compact, embeddable widget interface for Pipecat applications. It features a toggle button to show/hide the widget panel, which includes text input and audio controls.

--- a/docs/content/docs/visualizers/basic-visualizer.mdx
+++ b/docs/content/docs/visualizers/basic-visualizer.mdx
@@ -2,6 +2,16 @@
 title: Basic Visualizer
 description: Real-time audio spectrum visualizer with customizable bars and peak indicators
 component: VoiceVisualizer
+source: package/src/visualizers/VoiceVisualizer/index.tsx
+changelog:
+  - version: "v0.8.0"
+    date: "2026-02-25"
+    changes:
+      - "Optimized rendering performance."
+  - version: "v0.3.0"
+    date: "2025-09-17"
+    changes:
+      - "Added optional bar peaks: `noPeaks`, `peakLineColor`, `peakLineSpeed`, `peakLineThickness`, `peakOffset`, and `peakFadeSpeed` props."
 ---
 
 The `VoiceVisualizer` component provides a real-time audio spectrum visualization that displays frequency data as animated bars. It integrates with the Pipecat Client SDK to automatically connect to audio streams and provides extensive customization options for visual appearance and behavior.

--- a/docs/content/docs/visualizers/circular-waveform.mdx
+++ b/docs/content/docs/visualizers/circular-waveform.mdx
@@ -2,6 +2,9 @@
 title: Circular Waveform
 description: Real-time circular audio spectrum visualizer with dynamic rotation and color transitions
 component: CircularWaveform
+source:
+  - package/src/visualizers/CircularWaveform/index.tsx
+  - package/src/visualizers/CircularWaveform/canvas.ts
 ---
 
 The `CircularWaveform` component provides a real-time circular audio spectrum visualization that displays frequency data as animated bars arranged in a circle. It features dynamic rotation that responds to audio activity, smooth color transitions, and multiple visualization states for different interaction modes.

--- a/docs/content/docs/visualizers/plasma-visualizer.mdx
+++ b/docs/content/docs/visualizers/plasma-visualizer.mdx
@@ -2,6 +2,9 @@
 title: Plasma Visualizer (WebGL)
 description: WebGL-powered plasma effect visualizer with real-time audio reactivity and customizable rings
 component: PlasmaVisualizer
+source:
+  - package/src/visualizers/webgl/PlasmaVisualizer.tsx
+  - package/src/visualizers/webgl/Plasma.tsx
 ---
 
 <Callout>

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -6,6 +6,12 @@ import {
 } from "fumadocs-mdx/config";
 import { z } from "zod";
 
+const changelogEntrySchema = z.object({
+  version: z.string(),
+  date: z.string().optional(),
+  changes: z.array(z.string()).min(1),
+});
+
 // You can customise Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.vercel.app/docs/mdx/collections#define-docs
 export const docs = defineDocs({
@@ -14,6 +20,8 @@ export const docs = defineDocs({
     schema: frontmatterSchema.extend({
       componentName: z.string().optional(),
       componentImport: z.string().optional(),
+      source: z.union([z.string(), z.array(z.string())]).optional(),
+      changelog: z.array(changelogEntrySchema).optional(),
     }),
     postprocess: {
       includeProcessedMarkdown: true,


### PR DESCRIPTION
## Summary

Improves the docs in three ways:

1. **Per-page changelog**: every page that documents a public export can now declare a `changelog` array in frontmatter (version, date, bullet list of changes). The Changelog section auto-renders at the bottom of the page. Backtick identifiers render as inline code.
2. **Source link**: pages can declare a `source` path (string or array) pointing to the implementation under `package/src/`. A View source button is added next to the existing Open menu.
3. **Automated updates**: a new GitHub Actions workflow (`docs-update.yml`) listens for release-please PR events, runs claude-code-action over the package source diff, and opens or updates a sibling docs PR with proposed prose, prop table, and changelog edits, plus new pages for new exports.

The first 63 docs pages are backfilled with `source` paths and historical changelog entries seeded from `CHANGELOG.md` across v0.2.0 through v0.9.0. Backfill prioritizes accuracy over completeness: ambiguous changes were omitted rather than guessed.

## Required setup before the workflow can run

- Add `ANTHROPIC_API_KEY` to repo secrets.
- In Settings to Actions to General, allow GitHub Actions to create and approve pull requests (the workflow uses `gh pr create`).
- Optionally trust-but-verify the `anthropics/claude-code-action@v1` invocation if you prefer to pin a SHA.

## Test plan

- [x] Run `pnpm --filter @pipecat-ai/voice-ui-kit build` then `pnpm --filter @pipecat-ai/voice-ui-kit-docs dev`, open a backfilled page (e.g. `/components/Conversation`), verify the View source button links to the correct file and the Changelog renders with backticked identifiers.
- [x] Open a few pages with no source backing (`/`, `/styling`) and confirm no Changelog or View source button appears.
- [x] Skim the changelog on `Conversation`, `PipecatAppBase`, `UserAudioControl`, and `basic-visualizer` for accuracy. These pages aggregate the most CHANGELOG bullets and are the most likely place for misattribution.
- [ ] After merging, when the next release-please PR opens, verify a sibling `docs/release-vX.Y.Z` PR is created or updated automatically.