### PR TITLE
ci: grant id-token write to docs-update job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,10 @@ jobs:
     if: needs.release-please.outputs.release_pr_number != ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     concurrency:
       group: docs-update-${{ needs.release-please.outputs.release_pr_number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary

`claude-code-action@v1` requires an OIDC token internally even when authenticating via the Anthropic API key. The docs-update job inherited only `contents: write` and `pull-requests: write` from the workflow, so its first run failed with `Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?` ([run 25161344229](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/25161344229)).

Adds a job-level permissions block to docs-update that grants the three permissions it needs. The release-please and publish jobs are unaffected; publish already declares its own `id-token: write`.

## Test plan

- [ ] Re-run the Release Please workflow on \`main\` after merging. The docs-update job should now reach the Claude Code step instead of failing during OIDC fetch.