### PR TITLE
ci: resolve open release PR by label as docs-update fallback

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,13 +15,38 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs['package--release_created'] }}
-      release_pr_number: ${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).number || '' }}
+      release_pr_number: ${{ steps.find-pr.outputs.pr_number }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Resolve open release-please PR number
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The action only emits `pr` when it just opened or updated the PR.
+          # On reruns where nothing changed (e.g. workflow_dispatch with the
+          # release PR already in the desired state), the output is empty.
+          # Fall back to looking up the open release-please PR by its label
+          # so the docs-update job can still chain off it.
+          PR_FROM_ACTION='${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).number || '' }}'
+          if [ -n "$PR_FROM_ACTION" ]; then
+            echo "pr_number=$PR_FROM_ACTION" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(gh pr list \
+            --label 'autorelease: pending' \
+            --base main \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "pr_number=${PR_NUMBER:-}" >> "$GITHUB_OUTPUT"
 
   docs-update:
     # Runs whenever release-please has an open release PR (newly created or


### PR DESCRIPTION
## Summary

`googleapis/release-please-action` only emits its `pr` output when it just opened or updated the release PR on the current run. On reruns where the PR already matches the action's desired state (the common case on \`workflow_dispatch\`), the output is empty, so \`release_pr_number\` resolves to \`\`, and the \`docs-update\` job's \`if:\` condition skips it. That's what happened on [run 25161569473](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/25161569473): the log shows \`PR ...#124 remained the same\` and the job was skipped in 0s.

This change adds a small fallback step that, when the action's output is missing, looks up the open release-please PR by its \`autorelease: pending\` label. \`docs-update\` now fires consistently whether the action had work to do or not.

## Test plan

- [ ] After merge, run the Release Please workflow manually with PR #124 open. The \`Resolve open release-please PR number\` step should print PR 124, and \`docs-update\` should run instead of skipping.
- [ ] When PR #124 is eventually merged and there's no open release PR, \`docs-update\` should skip cleanly with an empty \`release_pr_number\`.