### PR TITLE
ci: switch docs-update to claude-code-base-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -128,7 +128,7 @@ jobs:
           find docs/content/docs -type f -name '*.mdx' | sort > .release-context/existing-pages.txt
 
       - name: Run Claude Code to update docs
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # `claude_args` are forwarded to the headless CLI; tune as needed.


### PR DESCRIPTION
## Summary

After fixing OIDC permissions in #126, the docs-update job hit a new error: \`Action failed with error: Unsupported event type: push\` ([run 25161721355](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/25161721355/job/73757647965)).

\`anthropics/claude-code-action@v1\` is the *interactive* variant, designed to be triggered by PR/issue comments. It expects an event payload with PR or issue context and rejects \`push\` and \`workflow_dispatch\`. \`anthropics/claude-code-base-action\` is the *headless* variant intended for workflow-driven runs; it accepts the same \`prompt\`, \`claude_args\`, and \`anthropic_api_key\` inputs.

Pinned to \`v0.0.63\` (latest tagged release) rather than \`@beta\` so the dependency is stable.

## Test plan

- [ ] After merge, run the Release Please workflow manually with PR #124 open. The Claude Code step should now actually invoke the model instead of rejecting the event type.