### PR TITLE
ci: bypass permission prompts in headless docs-update agent

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -132,9 +132,15 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # `claude_args` are forwarded to the headless CLI; tune as needed.
+          # `bypassPermissions` is appropriate here because the runner is
+          # ephemeral, the working tree is throwaway, and there is no human
+          # to answer permission prompts. The agent's blast radius is
+          # already constrained by `--allowed-tools` and by the prompt's
+          # explicit edit-scope rules.
           claude_args: |
             --max-turns 60
             --allowed-tools Read,Edit,Write,Bash,Grep,Glob
+            --permission-mode bypassPermissions
           prompt: |
             You are updating the documentation for the @pipecat-ai/voice-ui-kit
             release v${{ steps.ctx.outputs.next_version }} (previous release:


### PR DESCRIPTION
## Summary

The current run ([job 73758079788](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/25161843501/job/73758079788)) is hanging because Claude is prompting for write permission on each file:

> Claude requested permissions to write to /home/runner/.../.release-context/agent-summary.md, but you haven't granted it yet.

\`--allowed-tools\` enables tools but doesn't pre-grant per-operation permission. In a non-interactive CI run, those prompts have no recipient and the action blocks indefinitely. \`--permission-mode bypassPermissions\` skips them.

Safe here because:
- the runner is ephemeral and the working tree is throwaway,
- the prompt explicitly bounds the edit scope to \`docs/content/docs/\`,
- \`--allowed-tools\` already restricts to Read/Edit/Write/Bash/Grep/Glob.

## Test plan

- [ ] After merge, cancel the in-flight run and trigger Release Please manually. Claude should complete its edits without blocking on permission prompts.