### PR TITLE
ci: use claude-code-base-action's discrete inputs at v0.0.63

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -137,8 +137,11 @@ jobs:
           # ignored. There is no `permission_mode` input at this version;
           # the action's default already allows headless writes.
           allowed_tools: "Read,Edit,Write,Bash,Grep,Glob"
-          max_turns: "60"
-          timeout_minutes: "25"
+          max_turns: "150"
+          # Leaves 2 minutes for commit/push/PR steps under the 30-min
+          # job-level timeout. The agent will exit early if it finishes
+          # before the wall clock; this is a ceiling, not a target.
+          timeout_minutes: "28"
           prompt: |
             You are updating the documentation for the @pipecat-ai/voice-ui-kit
             release v${{ steps.ctx.outputs.next_version }} (previous release:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -131,16 +131,14 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # `claude_args` are forwarded to the headless CLI; tune as needed.
-          # `bypassPermissions` is appropriate here because the runner is
-          # ephemeral, the working tree is throwaway, and there is no human
-          # to answer permission prompts. The agent's blast radius is
-          # already constrained by `--allowed-tools` and by the prompt's
-          # explicit edit-scope rules.
-          claude_args: |
-            --max-turns 60
-            --allowed-tools Read,Edit,Write,Bash,Grep,Glob
-            --permission-mode bypassPermissions
+          # NB: at v0.0.63 the action exposes discrete inputs rather than
+          # the newer `claude_args` interface. Use `allowed_tools` /
+          # `max_turns` directly — passing `claude_args` here is silently
+          # ignored. There is no `permission_mode` input at this version;
+          # the action's default already allows headless writes.
+          allowed_tools: "Read,Edit,Write,Bash,Grep,Glob"
+          max_turns: "60"
+          timeout_minutes: "25"
           prompt: |
             You are updating the documentation for the @pipecat-ai/voice-ui-kit
             release v${{ steps.ctx.outputs.next_version }} (previous release:


### PR DESCRIPTION
## Summary

The previous run ([job 73758857473](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/25162068728/job/73758857473)) succeeded but committed nothing. Looking at the log, the action emitted:

> Unexpected input(s) 'claude_args', valid inputs are ['prompt', 'prompt_file', 'allowed_tools', 'disallowed_tools', 'max_turns', ...]

\`claude_args\` is a newer input only present on \`main\`; at the pinned \`v0.0.63\` tag the action declares discrete inputs (\`allowed_tools\`, \`max_turns\`, etc.). Our \`claude_args\` block was silently ignored, so the agent ran with default \`max_turns\` (10) and stopped mid-task — its own summary file ended with "Analysis in Progress...".

This PR uses the inputs v0.0.63 actually declares: \`allowed_tools\`, \`max_turns: "60"\`, plus \`timeout_minutes: "25"\` as a hard upper bound on a single agent invocation. Drops the \`--permission-mode\` flag since v0.0.63 doesn't expose that input and the default already permits writes (the previous run did successfully write files before being cut off).

## Test plan

- [ ] After merge, run Release Please manually. The agent should run for closer to 60 turns rather than 10, and the commit step should find changes to stage. Expect a new \`docs/release-v0.10.0\` PR.