### PR TITLE
ci: tighten docs-update agent prompt with formatting conventions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -175,9 +175,14 @@ jobs:
                Skip the changelog entry on a page if nothing on that page
                actually changed.
             3. **Verify the `source` frontmatter field** points to the correct
-               implementation file(s) under `package/src/`. Add or fix it if
-               wrong. Use a string for a single file, an array for multi-file
-               primitives.
+               implementation file(s) under `package/src/`. Must be a
+               repo-relative path (single string or array of strings).
+               Never put a package name like `@pipecat-ai/client-react`
+               in this field — the View source button generates a GitHub
+               link from it. If the documented export has been moved
+               entirely to an external package, point `source` at the
+               re-export site (typically `package/src/.../index.ts`) and
+               note the upstream location in the prose.
             4. **Create new docs pages** for any newly exported public API
                that has no corresponding page. Place them in the matching
                folder under `docs/content/docs/` (components, hooks, panels,
@@ -189,12 +194,36 @@ jobs:
                changelog entry noting the removal and add a banner at the top
                of the page explaining the removal. Flag these in your summary.
 
+            ## Formatting conventions
+            - Wrap component, hook, prop, type, and identifier names in
+              backtick code spans. Applies to changelog bullets and prose.
+              Examples: `` `Conversation` ``, `` `usePipecatConversation` ``,
+              `` `noTextInput` ``, `` `FunctionCallData` ``,
+              `` `ConversationMessage.role` ``.
+            - When mentioning an external `@pipecat-ai/*` package in
+              prose, render it as a link to its GitHub repo. Use:
+                - `[`@pipecat-ai/client-js`](https://github.com/pipecat-ai/pipecat-client-web)`
+                - `[`@pipecat-ai/client-react`](https://github.com/pipecat-ai/pipecat-client-web)`
+                - `[`@pipecat-ai/daily-transport`](https://github.com/pipecat-ai/pipecat-client-web-transports)`
+                - `[`@pipecat-ai/small-webrtc-transport`](https://github.com/pipecat-ai/pipecat-client-web-transports)`
+              In `changelog` frontmatter bullets, use only backticks for
+              package names (no markdown link), since the changelog
+              renderer does not parse links.
+            - When you edit a `<LiveComponent>` example, ensure the
+              resulting code can render. Components that read from
+              `PipecatClientProvider` (anything that uses
+              `useConversationContext`, `usePipecatClient`, etc.) need
+              `withPipecat` on the `<LiveComponent>` opening tag.
+              Removing a `<ConversationProvider>` wrapper without adding
+              `withPipecat` will produce a runtime error on the page.
+
             ## Constraints
             - Edit only files under `docs/content/docs/` and (for source
               verification) read `package/src/`. Do not touch
               `package/CHANGELOG.md`, the manifest, or the release config.
             - Match the existing prose style. Do not use em dashes.
             - Keep changelog bullets factual and short. No marketing language.
+            - Always end MDX files with a trailing newline.
             - If something is ambiguous, leave a clear `{/* TODO: ... */}`
               MDX comment in the page rather than guessing.
 


### PR DESCRIPTION
## Summary

The first real agent run produced a usable docs PR (#131) but with a handful of rough edges that needed manual cleanup. This PR teaches the agent to avoid those issues going forward by adding explicit conventions to its prompt.

Issues observed and now covered:

1. **Broken \`<LiveComponent>\` examples.** The agent removed \`<ConversationProvider>\` wrappers (correct, since it's no longer required at v0.10.0) but didn't add \`withPipecat\` to the \`<LiveComponent>\` opening tag. The components fell over at render time with \`useConversationContext must be used within a PipecatClientProvider\`. The prompt now spells out the LiveComponent + \`withPipecat\` invariant.

2. **Identifier names missing backticks.** Props, types, components, and hooks were unstyled in changelog bullets and prose. The prompt now lists explicit examples and applies the rule to both changelog and prose.

3. **External package mentions weren't linked.** Mentions of \`@pipecat-ai/client-react\`, \`@pipecat-ai/client-js\`, etc. should link to the upstream repos in prose. The prompt now provides exact link targets for the four packages we cite. (Frontmatter changelog bullets use plain backticks since the renderer doesn't parse links yet.)

4. **Invalid \`source\` frontmatter.** One page got \`source: \"@pipecat-ai/client-react\"\`, which the View source button would render as a broken GitHub link. The prompt now states clearly that \`source\` must be a repo-relative path, with guidance on how to handle exports that have moved upstream.

5. **Trailing newline reminder.** One page lost its trailing newline.

## Test plan

- [ ] After merge, when the next release-please PR triggers a docs-update run, eyeball the resulting docs PR for: backticked identifiers, linked package mentions, \`withPipecat\` on examples that need it, valid \`source\` paths, trailing newlines.