### PR TITLE
ci: preserve docs branch state across docs-update runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -97,10 +97,23 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Reset the docs branch to current main on every run so the agent
-          # always works from the latest state.
-          git fetch origin "$DOCS_BRANCH" || true
-          git checkout -B "$DOCS_BRANCH" origin/main
+          # If the docs branch already exists on the remote (i.e. the
+          # docs PR is already open from a prior run, possibly with
+          # manual fixes on top), branch from there so the agent
+          # incrementally updates instead of starting from scratch.
+          # Otherwise branch from main.
+          if git fetch origin "$DOCS_BRANCH" 2>/dev/null; then
+            git checkout -B "$DOCS_BRANCH" "origin/$DOCS_BRANCH"
+            # Bring the branch up to date with main without losing local
+            # commits. If main has moved forward, merge it in.
+            git merge --no-edit origin/main || {
+              echo "::warning::Merge from main into $DOCS_BRANCH had conflicts; falling back to main and dropping prior docs branch state."
+              git merge --abort || true
+              git checkout -B "$DOCS_BRANCH" origin/main
+            }
+          else
+            git checkout -B "$DOCS_BRANCH" origin/main
+          fi
 
       - name: Collect release context
         id: collect
@@ -156,6 +169,17 @@ jobs:
             - `.release-context/existing-pages.txt` — every existing docs page.
             - `docs/content/docs/**/*.mdx` — current docs (read and edit).
             - `package/src/**` — current source (read only).
+
+            **Note on incremental runs.** This workflow may run multiple
+            times for the same release as the release-please PR is
+            updated. The docs branch is preserved between runs, so the
+            current state of `docs/content/docs/**/*.mdx` may already
+            include changelog entries for the upcoming version (from a
+            prior agent run) and possibly manual fixes on top. Treat
+            existing changes as authoritative: don't duplicate changelog
+            entries you've already added, don't re-apply prose changes
+            that are already reflected, and don't overwrite manual
+            edits that look intentional. Only add what's missing.
 
             ## What to do
             For every change in the diff that affects a public export
@@ -245,12 +269,20 @@ jobs:
           # Strip the throwaway context dir before committing.
           rm -rf .release-context
           git add docs/content/docs
-          if git diff --cached --quiet; then
+          # `changed` covers two cases: the agent edited files in this
+          # run, or a merge with main brought in new commits. Either way
+          # we have something worth pushing.
+          if git diff --cached --quiet && [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$DOCS_BRANCH" 2>/dev/null || git rev-parse origin/main)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git commit -m "docs: update for v$NEXT_VERSION"
-          git push --force-with-lease origin "$DOCS_BRANCH"
+          if ! git diff --cached --quiet; then
+            git commit -m "docs: update for v$NEXT_VERSION"
+          fi
+          # Fast-forward push (the branch was either freshly created from
+          # main, or extended on top of its own previous tip). No force
+          # is needed in the common path.
+          git push origin "$DOCS_BRANCH"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open or update docs PR


### PR DESCRIPTION
## Summary

Today, every \`docs-update\` run resets the docs branch to current \`main\` via \`git checkout -B \"\$DOCS_BRANCH\" origin/main\`. This has two unintended consequences:

1. **Wasted work.** The agent re-does the same edits from scratch on every release-please PR update, even though prior runs produced the same content.
2. **Manual fixes silently destroyed.** If a maintainer pushes a fix to the docs PR (for example, the cleanup we just did on #131), the very next workflow run wipes it. We've gotten lucky so far that #131 hasn't re-triggered, but this is a real footgun.

This PR changes the prepare step to branch from \`origin/\$DOCS_BRANCH\` when it exists, merging in \`origin/main\` if main has moved forward. Falls back to branching from \`main\` when there's no prior branch or the merge would conflict. The push step is now a fast-forward in the common path (no force-push).

The agent prompt also gains a "Note on incremental runs" section instructing it to treat existing changes as authoritative and only fill in gaps, so we don't get duplicate changelog entries.

## Test plan

- [ ] After merge, trigger Release Please with PR #124 still open. The first run should branch from main and create the docs PR. Trigger a second run; the prepare step should branch from \`origin/docs/release-vX.Y.Z\` and the agent should make minimal additional edits (or none if nothing has changed).
- [ ] Push a manual fix to a docs PR, then trigger another run. The manual fix should survive.
- [ ] When release-please bumps the version (e.g. v0.10.0 → v0.11.0), the next run should branch from main fresh because the new branch name (\`docs/release-v0.11.0\`) won't exist yet. Verify behavior matches.