### PR TITLE
docs: improve websocket transport and onClient guidance

### DIFF
--- a/docs/content/docs/components/PipecatAppBase.mdx
+++ b/docs/content/docs/components/PipecatAppBase.mdx
@@ -226,13 +226,19 @@ export default function Home() {
 
 ### 7. Using WebSocket Transport
 
-You can use the WebSocket transport for server-side connections. First, install the WebSocket transport package:
+The `websocket` transport is provided by an optional peer package that must be installed alongside the kit.
+
+<Callout type="warning">
+  The WebSocket transport package is a peer dependency. Install it before
+  setting `transportType="websocket"`, otherwise the transport will fail to
+  load at runtime.
+</Callout>
 
 ```bash
 npm install @pipecat-ai/websocket-transport
 ```
 
-Then use it in your component:
+Then point the component at a `startBot` endpoint that returns WebSocket connection details:
 
 ```tsx
 import { PipecatAppBase } from "@pipecat-ai/voice-ui-kit";
@@ -241,8 +247,11 @@ export default function Home() {
   return (
     <PipecatAppBase
       transportType="websocket"
-      connectParams={{
-        url: "wss://your-websocket-server.com/ws",
+      startBotParams={{
+        endpoint: "/api/start",
+        requestData: {
+          transport: "websocket",
+        },
       }}
     >
       <YourCustomComponent />
@@ -251,19 +260,24 @@ export default function Home() {
 }
 ```
 
+Transport-specific construction options can be passed via `transportOptions`, which is typed as `WebSocketTransportConstructorOptions` when `transportType="websocket"`. See the [@pipecat-ai/websocket-transport](https://www.npmjs.com/package/@pipecat-ai/websocket-transport) package for the full option list.
+
 ### 8. Using onClient Callback
 
-You can use the `onClient` callback to subscribe to client events before connecting:
+`onClient` fires once per client instance, the moment the client is created and before any connect attempt. It's the right place to attach `client.on(...)` listeners or to run setup that needs the client handle from outside the provider tree (e.g. when consuming `ConsoleTemplate`, where there is no render-prop slot to call `usePipecatClient()` from).
+
+It fires again each time the client is recreated, for example when `transportType`, `transportOptions`, or `clientOptions` change. Treat each call as a fresh subscription point.
 
 ```tsx
 import { PipecatAppBase } from "@pipecat-ai/voice-ui-kit";
+import { type PipecatClient, RTVIEvent } from "@pipecat-ai/client-js";
 
 export default function Home() {
-  const handleClient = (client) => {
-    client.on("botStartedSpeaking", () => {
+  const handleClient = (client: PipecatClient) => {
+    client.on(RTVIEvent.BotStartedSpeaking, () => {
       console.log("Bot started speaking");
     });
-    client.on("userStartedSpeaking", () => {
+    client.on(RTVIEvent.UserStartedSpeaking, () => {
       console.log("User started speaking");
     });
   };
@@ -280,6 +294,29 @@ export default function Home() {
     </PipecatAppBase>
   );
 }
+```
+
+A common use case is bootstrapping a transport-specific handshake on connect. For example, sending Twilio's expected `connected` and `start` messages immediately after the WebSocket transport opens:
+
+```tsx
+import { PipecatAppBase } from "@pipecat-ai/voice-ui-kit";
+import { type PipecatClient, RTVIEvent } from "@pipecat-ai/client-js";
+import { type WebSocketTransport } from "@pipecat-ai/websocket-transport";
+
+const handleClient = (client: PipecatClient) => {
+  client.on(RTVIEvent.Connected, () => {
+    const transport = client.transport as WebSocketTransport;
+    void transport.sendRawMessage({
+      event: "connected",
+      protocol: "Call",
+      version: "1.0.0",
+    });
+    void transport.sendRawMessage({
+      event: "start",
+      start: { streamSid: "mock", callSid: "mock" },
+    });
+  });
+};
 ```
 
 ### 9. Using startBotParams

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -47,33 +47,41 @@ yarn add @pipecat-ai/client-js @pipecat-ai/client-react
 ```
 
 ```bash tab="bun"
-bun add @pipecat-ai/small-webrtc-transport 
-# or
-bun add @pipecat-ai/daily-transport
+bun add @pipecat-ai/client-js @pipecat-ai/client-react
 ```
 
 And finally, your chosen transport package:
 
 ```bash tab="npm"
-npm install @pipecat-ai/small-webrtc-transport 
+npm install @pipecat-ai/small-webrtc-transport
 # or
 npm install @pipecat-ai/daily-transport
+# or
+npm install @pipecat-ai/websocket-transport
 ```
 
 ```bash tab="pnpm"
-pnpm add @pipecat-ai/small-webrtc-transport 
+pnpm add @pipecat-ai/small-webrtc-transport
 # or
 pnpm add @pipecat-ai/daily-transport
+# or
+pnpm add @pipecat-ai/websocket-transport
 ```
 
 ```bash tab="yarn"
-yarn add @pipecat-ai/small-webrtc-transport 
+yarn add @pipecat-ai/small-webrtc-transport
 # or
 yarn add @pipecat-ai/daily-transport
+# or
+yarn add @pipecat-ai/websocket-transport
 ```
 
 ```bash tab="bun"
-bun add @@pipecat-ai/client-js @pipecat-ai/client-react
+bun add @pipecat-ai/small-webrtc-transport
+# or
+bun add @pipecat-ai/daily-transport
+# or
+bun add @pipecat-ai/websocket-transport
 ```
 
 ## Templates

--- a/docs/content/docs/templates/console.mdx
+++ b/docs/content/docs/templates/console.mdx
@@ -109,6 +109,34 @@ export default function App() {
 }
 ```
 
+### With WebSocket Transport
+
+The `websocket` transport requires installing the optional peer package:
+
+```bash
+npm install @pipecat-ai/websocket-transport
+```
+
+```tsx
+import { ConsoleTemplate } from "@pipecat-ai/voice-ui-kit";
+
+export default function App() {
+  return (
+    <div className="h-screen">
+      <ConsoleTemplate
+        transportType="websocket"
+        startBotParams={{
+          endpoint: "/api/start",
+          requestData: {
+            transport: "websocket",
+          },
+        }}
+      />
+    </div>
+  );
+}
+```
+
 ### Custom Configuration
 
 ```tsx
@@ -431,15 +459,17 @@ Subscribe to server messages:
 
 ### onClient
 
-Subscribe to client events before connecting:
+Subscribe to client events before connecting. Fires once per client instance, on creation and before connect. See [`PipecatAppBase` › `onClient`](/docs/components/PipecatAppBase#using-onclient-callback) for full semantics.
 
 ```tsx
+import { type PipecatClient, RTVIEvent } from "@pipecat-ai/client-js";
+
 <ConsoleTemplate
-  onClient={(client) => {
-    client.on("botStartedSpeaking", () => {
+  onClient={(client: PipecatClient) => {
+    client.on(RTVIEvent.BotStartedSpeaking, () => {
       console.log("Bot started speaking");
     });
-    client.on("userStartedSpeaking", () => {
+    client.on(RTVIEvent.UserStartedSpeaking, () => {
       console.log("User started speaking");
     });
   }}


### PR DESCRIPTION
## Summary

Follow-up to [#137](https://github.com/pipecat-ai/voice-ui-kit/pull/137) to tighten the docs around the new `websocket` transport type and `onClient` prop.

- **`PipecatAppBase` › WebSocket Transport**: replace the `connectParams={{ url: ... }}` example (couldn't verify that shape) with the `startBotParams` flow that matches the merged 01 example. Surface the peer-dep install in a warning Callout. Mention `WebSocketTransportConstructorOptions` and link out for transport-specific options.
- **`PipecatAppBase` › `onClient`**: document the semantics (fires once per client instance, on creation, before connect, and again on recreation). Type the callback argument. Switch event names from string literals to the `RTVIEvent` enum to match the rest of the codebase. Add the motivating example: a WebSocket bootstrap that sends Twilio-style handshake messages on `Connected`.
- **Console template**: add a "With WebSocket Transport" block mirroring the Daily one. Apply the same typing/enum fixes to the `onClient` example.
- **Getting started**: add `@pipecat-ai/websocket-transport` to the install instructions across all four package managers. Fix two pre-existing bun-tab bugs in the same section (swapped content between blocks, and a stray double `@` in `@@pipecat-ai/client-js`).

Docs build verified locally with `pnpm build`.

## Test plan

- [x] `cd docs && pnpm build` succeeds
- [x] Spot-check the rendered `PipecatAppBase` page: WebSocket section reads cleanly, Callout renders, `onClient` semantics paragraph is present, Twilio bootstrap example renders.
- [x] Spot-check the rendered Console template page: new "With WebSocket Transport" block appears between Daily and Custom Configuration; `onClient` callback example shows `RTVIEvent.*`.
- [x] Spot-check the getting-started page: install instructions list `websocket-transport` alongside `small-webrtc-transport` and `daily-transport`; the bun tab in the "For usage with Pipecat" block now lists `client-js`/`client-react`; no stray `@@`.