### PR TITLE
add MoQ transport support

### DIFF
--- a/docs/content/docs/components/PipecatAppBase.mdx
+++ b/docs/content/docs/components/PipecatAppBase.mdx
@@ -262,7 +262,79 @@ export default function Home() {
 
 Transport-specific construction options can be passed via `transportOptions`, which is typed as `WebSocketTransportConstructorOptions` when `transportType="websocket"`. See the [@pipecat-ai/websocket-transport](https://www.npmjs.com/package/@pipecat-ai/websocket-transport) package for the full option list.
 
-### 8. Using onClient Callback
+### 8. Using MoQ Transport
+
+The `moq` transport speaks [Media-over-QUIC](https://datatracker.ietf.org/group/moq/about/) to a Pipecat bot via a moq-lite relay, using WebTransport (with a WebSocket fallback). Like the WebSocket transport, it's provided by an optional peer package.
+
+<Callout type="warning">
+  The MoQ transport is **pre-alpha**. The package is published, but the API and
+  catalog format may change between releases. Pin a version and expect breakage
+  on upgrade.
+</Callout>
+
+<Callout type="warning">
+  The MoQ transport package is a peer dependency. Install it before setting
+  `transportType="moq"`, otherwise the transport will fail to load at runtime.
+</Callout>
+
+```bash
+npm install @pipecat-ai/moq-transport
+```
+
+MoQ connects through a moq-lite relay. Typically the bot's `startBot` endpoint returns the relay connection details, so it's wired like the other transports:
+
+```tsx
+import { PipecatAppBase } from "@pipecat-ai/voice-ui-kit";
+
+export default function Home() {
+  return (
+    <PipecatAppBase
+      transportType="moq"
+      startBotParams={{
+        endpoint: "/api/start",
+        requestData: {
+          transport: "moq",
+        },
+      }}
+    >
+      <YourCustomComponent />
+    </PipecatAppBase>
+  );
+}
+```
+
+Alternatively, to dial a relay directly without a start endpoint, pass the relay URL via `transportOptions`:
+
+```tsx
+<PipecatAppBase
+  transportType="moq"
+  transportOptions={{
+    relayUrl: "https://relay.example.com:4080/",
+  }}
+>
+  <YourCustomComponent />
+</PipecatAppBase>
+```
+
+For local development against a self-signed relay, pin the certificate via `serverCertificateHashes` (same shape as the native WebTransport option):
+
+```tsx
+<PipecatAppBase
+  transportType="moq"
+  transportOptions={{
+    relayUrl: "https://localhost:4080/",
+    serverCertificateHashes: [
+      { algorithm: "sha-256", value: certHashBytes },
+    ],
+  }}
+>
+  <YourCustomComponent />
+</PipecatAppBase>
+```
+
+`MoqTransportOptions` also accepts `namespace`, `clientId`, `botId`, `transcriptTrack`, and `audioLatencyMs` for tuning the broadcast paths and jitter buffer. See the [@pipecat-ai/moq-transport](https://www.npmjs.com/package/@pipecat-ai/moq-transport) package for the full option list.
+
+### 9. Using onClient Callback
 
 `onClient` fires once per client instance, the moment the client is created and before any connect attempt. It's the right place to attach `client.on(...)` listeners or to run setup that needs the client handle from outside the provider tree (e.g. when consuming `ConsoleTemplate`, where there is no render-prop slot to call `usePipecatClient()` from).
 
@@ -319,7 +391,7 @@ const handleClient = (client: PipecatClient) => {
 };
 ```
 
-### 9. Using startBotParams
+### 10. Using startBotParams
 
 You can use `startBotParams` instead of `connectParams` to start a bot session:
 
@@ -364,14 +436,14 @@ export default function Home() {
     },
     transportType: {
       description:
-        "The type of transport to use for the connection (smallwebrtc, daily, or websocket)",
-      type: '"smallwebrtc" | "daily" | "websocket"',
+        "The type of transport to use for the connection (smallwebrtc, daily, websocket, or moq)",
+      type: '"smallwebrtc" | "daily" | "websocket" | "moq"',
       required: true,
     },
     transportOptions: {
       description:
-        "Optional configuration options for the transport (SmallWebRTC, Daily, or WebSocket specific)",
-      type: "SmallWebRTCTransportConstructorOptions | DailyTransportConstructorOptions | WebSocketTransportConstructorOptions",
+        "Optional configuration options for the transport (SmallWebRTC, Daily, WebSocket, or MoQ specific)",
+      type: "SmallWebRTCTransportConstructorOptions | DailyTransportConstructorOptions | WebSocketTransportConstructorOptions | MoqTransportOptions",
       required: false,
     },
     clientOptions: {

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -58,6 +58,8 @@ npm install @pipecat-ai/small-webrtc-transport
 npm install @pipecat-ai/daily-transport
 # or
 npm install @pipecat-ai/websocket-transport
+# or
+npm install @pipecat-ai/moq-transport
 ```
 
 ```bash tab="pnpm"
@@ -66,6 +68,8 @@ pnpm add @pipecat-ai/small-webrtc-transport
 pnpm add @pipecat-ai/daily-transport
 # or
 pnpm add @pipecat-ai/websocket-transport
+# or
+pnpm add @pipecat-ai/moq-transport
 ```
 
 ```bash tab="yarn"
@@ -74,6 +78,8 @@ yarn add @pipecat-ai/small-webrtc-transport
 yarn add @pipecat-ai/daily-transport
 # or
 yarn add @pipecat-ai/websocket-transport
+# or
+yarn add @pipecat-ai/moq-transport
 ```
 
 ```bash tab="bun"
@@ -82,6 +88,8 @@ bun add @pipecat-ai/small-webrtc-transport
 bun add @pipecat-ai/daily-transport
 # or
 bun add @pipecat-ai/websocket-transport
+# or
+bun add @pipecat-ai/moq-transport
 ```
 
 ## Templates

--- a/docs/content/docs/templates/console.mdx
+++ b/docs/content/docs/templates/console.mdx
@@ -144,6 +144,51 @@ export default function App() {
 }
 ```
 
+### With MoQ Transport
+
+The `moq` (Media-over-QUIC) transport requires installing the optional peer package:
+
+```bash
+npm install @pipecat-ai/moq-transport
+```
+
+<Callout type="warning">
+  The MoQ transport is pre-alpha. Pin a version and expect breakage on upgrade.
+</Callout>
+
+MoQ connects through a moq-lite relay. Typically the bot's `startBot` endpoint returns the relay connection details, so it's wired like the other transports:
+
+```tsx
+import { ConsoleTemplate } from "@pipecat-ai/voice-ui-kit";
+
+export default function App() {
+  return (
+    <div className="h-screen">
+      <ConsoleTemplate
+        transportType="moq"
+        startBotParams={{
+          endpoint: "/api/start",
+          requestData: {
+            transport: "moq",
+          },
+        }}
+      />
+    </div>
+  );
+}
+```
+
+Alternatively, to dial a relay directly without a start endpoint, pass the relay URL via `transportOptions`:
+
+```tsx
+<ConsoleTemplate
+  transportType="moq"
+  transportOptions={{
+    relayUrl: "https://relay.example.com:4080/",
+  }}
+/>
+```
+
 ### Custom Configuration
 
 ```tsx

--- a/examples/01-console/package.json
+++ b/examples/01-console/package.json
@@ -16,6 +16,7 @@
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/voice-ui-kit": "workspace:*",
     "@pipecat-ai/websocket-transport": ">=1.6.2",
+    "@pipecat-ai/moq-transport": "^0.1.0",
     "next": "15.5.18",
     "uuid": "^14.0.0",
     "react": "^19.2.1",

--- a/examples/01-console/src/app/page.tsx
+++ b/examples/01-console/src/app/page.tsx
@@ -7,12 +7,13 @@ import {
 } from "@pipecat-ai/voice-ui-kit";
 import React, { useState } from "react";
 
-type TransportType = "smallwebrtc" | "daily" | "websocket";
+type TransportType = "smallwebrtc" | "daily" | "websocket" | "moq";
 
 const TRANSPORT_OPTIONS: { value: TransportType; label: string }[] = [
   { value: "smallwebrtc", label: "SmallWebRTC" },
   { value: "daily", label: "Daily" },
   { value: "websocket", label: "WebSocket" },
+  { value: "moq", label: "MoQ" },
 ];
 
 type TransportProps = Pick<
@@ -55,6 +56,15 @@ function getTransportProps(
           endpoint: `${botHost}/start`,
           requestData: {
             transport: "websocket",
+          },
+        },
+      };
+    case "moq":
+      return {
+        startBotParams: {
+          endpoint: `${botHost}/start`,
+          requestData: {
+            transport: "moq",
           },
         },
       };

--- a/package/package.json
+++ b/package/package.json
@@ -49,6 +49,7 @@
     "@pipecat-ai/client-js": ">=1.13.0",
     "@pipecat-ai/client-react": ">=1.8.0",
     "@pipecat-ai/daily-transport": ">=1.6.0",
+    "@pipecat-ai/moq-transport": "^0.1.0",
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/websocket-transport": ">=1.6.2",
     "react": ">=16.8.0 || >=17.0.0 || >=18.0.0",
@@ -71,6 +72,10 @@
     "@pipecat-ai/daily-transport": {
       "optional": true,
       "version": "^1.6.0"
+    },
+    "@pipecat-ai/moq-transport": {
+      "optional": true,
+      "version": "^0.1.0"
     },
     "@pipecat-ai/small-webrtc-transport": {
       "optional": true,
@@ -124,6 +129,7 @@
     "@pipecat-ai/client-js": "^1.13.0",
     "@pipecat-ai/client-react": "^1.8.0",
     "@pipecat-ai/daily-transport": "^1.6.0",
+    "@pipecat-ai/moq-transport": "^0.1.0",
     "@pipecat-ai/small-webrtc-transport": "^1.9.0",
     "@pipecat-ai/websocket-transport": "^1.6.2",
     "@tailwindcss/vite": "^4.1.13",

--- a/package/src/components/PipecatAppBase.tsx
+++ b/package/src/components/PipecatAppBase.tsx
@@ -5,7 +5,7 @@ import {
   ThemeProvider,
   type ThemeProviderProps,
 } from "@/components/ThemeProvider";
-import { createTransport } from "@/lib/transports";
+import { createTransport, type MoqTransportOptions } from "@/lib/transports";
 import {
   APIRequest,
   PipecatClient,
@@ -35,12 +35,13 @@ export interface PipecatBaseProps {
     response: TransportConnectionParams,
   ) => TransportConnectionParams | Promise<TransportConnectionParams>;
   /** Type of transport to use for the connection */
-  transportType: "smallwebrtc" | "daily" | "websocket";
+  transportType: "smallwebrtc" | "daily" | "websocket" | "moq";
   /** Options for configuring the transport. */
   transportOptions?:
     | SmallWebRTCTransportConstructorOptions
     | DailyTransportConstructorOptions
-    | WebSocketTransportConstructorOptions;
+    | WebSocketTransportConstructorOptions
+    | MoqTransportOptions;
   /** Optional configuration options for the Pipecat client */
   clientOptions?: Partial<PipecatClientOptions>;
   /** Whether to disable the theme provider */
@@ -65,8 +66,7 @@ export interface PipecatBaseProps {
    * @returns React.ReactNode
    */
   children:
-    | ((props: PipecatBaseChildProps) => React.ReactNode)
-    | React.ReactNode;
+    ((props: PipecatBaseChildProps) => React.ReactNode) | React.ReactNode;
 }
 
 /**

--- a/package/src/components/elements/SessionInfo.tsx
+++ b/package/src/components/elements/SessionInfo.tsx
@@ -36,17 +36,19 @@ export const SessionInfo: React.FC<Props> = ({
     setServerVersion(botData.version);
   });
 
+  const transportServiceName = (
+    client?.transport as unknown as {
+      __proto__?: { constructor?: { SERVICE_NAME?: string } };
+    } | null
+  )?.__proto__?.constructor?.SERVICE_NAME;
+
   let transportTypeName = "Unknown";
   if (client && "dailyCallClient" in client.transport) {
     transportTypeName = `Daily (v${Daily.version()})`;
-  } else if (
-    (
-      client?.transport as unknown as {
-        __proto__: { constructor: { SERVICE_NAME?: string } };
-      } | null
-    )?.__proto__.constructor.SERVICE_NAME === "small-webrtc-transport"
-  ) {
+  } else if (transportServiceName === "small-webrtc-transport") {
     transportTypeName = "Small WebRTC";
+  } else if (transportServiceName === "moq-transport") {
+    transportTypeName = "MoQ";
   }
 
   const data: React.ComponentProps<typeof DataList>["data"] = {};

--- a/package/src/components/metrics/Metrics.tsx
+++ b/package/src/components/metrics/Metrics.tsx
@@ -197,7 +197,8 @@ export const Metrics: React.FC<Props> = ({
       tooltip: {
         callbacks: {
           label: function (context) {
-            return `${context.dataset.label}: ${context.parsed.y.toFixed(2)} ms`;
+            const y = context.parsed.y;
+            return `${context.dataset.label}: ${y === null ? "N/A" : y.toFixed(2)} ms`;
           },
         },
       },

--- a/package/src/lib/transports.ts
+++ b/package/src/lib/transports.ts
@@ -1,6 +1,6 @@
 import type { Transport } from "@pipecat-ai/client-js";
 
-export type TransportType = "daily" | "smallwebrtc" | "websocket";
+export type TransportType = "daily" | "smallwebrtc" | "websocket" | "moq";
 
 // Use the actual types from the packages without importing them at build time
 export type DailyTransportOptions = ConstructorParameters<
@@ -12,11 +12,15 @@ export type SmallWebRTCTransportOptions = ConstructorParameters<
 export type WebSocketTransportOptions = ConstructorParameters<
   typeof import("@pipecat-ai/websocket-transport").WebSocketTransport
 >[0];
+export type MoqTransportOptions = ConstructorParameters<
+  typeof import("@pipecat-ai/moq-transport").MoqTransport
+>[0];
 
 export interface TransportModule {
   DailyTransport: typeof import("@pipecat-ai/daily-transport").DailyTransport;
   SmallWebRTCTransport: typeof import("@pipecat-ai/small-webrtc-transport").SmallWebRTCTransport;
   WebSocketTransport: typeof import("@pipecat-ai/websocket-transport").WebSocketTransport;
+  MoqTransport: typeof import("@pipecat-ai/moq-transport").MoqTransport;
 }
 
 /**
@@ -42,6 +46,10 @@ export async function loadTransport(transportType: TransportType) {
         );
         return { WebSocketTransport };
       }
+      case "moq": {
+        const { MoqTransport } = await import("@pipecat-ai/moq-transport");
+        return { MoqTransport };
+      }
       default:
         throw new Error(`Unsupported transport type: ${transportType}`);
     }
@@ -53,7 +61,9 @@ export async function loadTransport(transportType: TransportType) {
         ? "npm install @pipecat-ai/daily-transport"
         : transportType === "smallwebrtc"
           ? "npm install @pipecat-ai/small-webrtc-transport"
-          : "npm install @pipecat-ai/websocket-transport";
+          : transportType === "websocket"
+            ? "npm install @pipecat-ai/websocket-transport"
+            : "npm install @pipecat-ai/moq-transport";
     throw new Error(
       `Failed to load transport "${transportType}". Make sure the package is installed: ${installHint}. Original error: ${errorMessage}`,
     );
@@ -63,7 +73,7 @@ export async function loadTransport(transportType: TransportType) {
 /**
  * Creates a transport instance based on the transport type.
  *
- * @param transportType - The type of transport to create ("daily" or "smallwebrtc")
+ * @param transportType - The type of transport to create ("daily", "smallwebrtc", "websocket", or "moq")
  * @param options - Transport-specific options
  *
  */
@@ -80,18 +90,24 @@ export async function createTransport(
   options?: WebSocketTransportOptions,
 ): Promise<Transport>;
 export async function createTransport(
-  transportType: TransportType,
-  options?:
-    | DailyTransportOptions
-    | SmallWebRTCTransportOptions
-    | WebSocketTransportOptions,
+  transportType: "moq",
+  options?: MoqTransportOptions,
 ): Promise<Transport>;
 export async function createTransport(
   transportType: TransportType,
   options?:
     | DailyTransportOptions
     | SmallWebRTCTransportOptions
-    | WebSocketTransportOptions,
+    | WebSocketTransportOptions
+    | MoqTransportOptions,
+): Promise<Transport>;
+export async function createTransport(
+  transportType: TransportType,
+  options?:
+    | DailyTransportOptions
+    | SmallWebRTCTransportOptions
+    | WebSocketTransportOptions
+    | MoqTransportOptions,
 ): Promise<Transport> {
   const transportModule = await loadTransport(transportType);
 
@@ -116,6 +132,13 @@ export async function createTransport(
         throw new Error("WebSocketTransport not found in loaded module");
       }
       return new WebSocketTransport(options as WebSocketTransportOptions);
+    }
+    case "moq": {
+      const { MoqTransport } = transportModule;
+      if (!MoqTransport) {
+        throw new Error("MoqTransport not found in loaded module");
+      }
+      return new MoqTransport(options as MoqTransportOptions);
     }
     default:
       throw new Error(`Unsupported transport type: ${transportType}`);

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -70,8 +70,10 @@ import { KeypadToggle } from "./KeypadToggle";
 import { SmallWebRTCCodecSetter } from "./SmallWebRTCCodecSetter";
 import UserScreenControl from "../../components/elements/UserScreenControl";
 
-export interface ConsoleTemplateProps
-  extends Omit<PipecatBaseProps, "children"> {
+export interface ConsoleTemplateProps extends Omit<
+  PipecatBaseProps,
+  "children"
+> {
   /** Disables RTVI related functionality. Default: false */
   noRTVI?: boolean;
   /** Specifies the RTVI version in use by the server. Default: null */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@pipecat-ai/daily-transport':
         specifier: '>=1.6.0'
         version: 1.6.0(@pipecat-ai/client-js@1.13.0)
+      '@pipecat-ai/moq-transport':
+        specifier: ^0.1.0
+        version: 0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
       '@pipecat-ai/small-webrtc-transport':
         specifier: '>=1.9.0'
         version: 1.9.0(@pipecat-ai/client-js@1.13.0)
@@ -515,6 +518,9 @@ importers:
       '@pipecat-ai/daily-transport':
         specifier: ^1.6.0
         version: 1.6.0(@pipecat-ai/client-js@1.13.0)
+      '@pipecat-ai/moq-transport':
+        specifier: ^0.1.0
+        version: 0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
       '@pipecat-ai/small-webrtc-transport':
         specifier: ^1.9.0
         version: 1.9.0(@pipecat-ai/client-js@1.13.0)
@@ -1167,89 +1173,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1333,6 +1355,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kixelated/libavjs-webcodecs-polyfill@0.5.5':
+    resolution: {integrity: sha512-Q1zgnTMMQ2F7IE9ylx3C1XzVbg5vYN18jiDINO5U3kNPBOHdYuUlJsMhtBoqr1M6ocLtoiqdHmLs7tHFgrw5KA==}
+
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
@@ -1368,6 +1393,12 @@ packages:
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
 
+  '@libav.js/types@6.9.8':
+    resolution: {integrity: sha512-5EEW2IT2VYBYzq14+jsKh8LIwImD0ldsh7m0x/66WNvUG2QljUXsvYV5B00Scx5boVph3WYbtsiLmT0HfUIDRQ==}
+
+  '@libav.js/variant-opus-af@6.9.8':
+    resolution: {integrity: sha512-4v4kBOoNnmafubEiBof+ATtr7KcU2/kL+G2hXU61orvC4Lt5OViBXnHdUHCh5ZSQQSmx9nOFEgbYGGYTrBufXQ==}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -1379,6 +1410,59 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@moq/flate@0.1.1':
+    resolution: {integrity: sha512-fHuA97OMdvwco/muP01hsg/AxEHzG9Xzr0tuLXI9TXBj7XuZ0uXiIQ4qv26kL6s+emkui/nlieGbr/NvWbPTKQ==}
+
+  '@moq/hang@0.2.16':
+    resolution: {integrity: sha512-Zggd8Y4C6EVrVBc1+ZqXP04Hg9ymWYyD4YBimMSvufOr4PNHkz7QqRZMe1wrkw++pVq61iYuFalqyQdbXNaGpA==}
+
+  '@moq/json@0.1.2':
+    resolution: {integrity: sha512-sQz86Iz29lzJIyzY6OtBqJHXxqtcDj2DypPNSEbHSwUQCcOxEzkMS2vhNZEK+oTRN6DpblTmelBeZJPg4RjkjA==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@moq/json@0.2.2':
+    resolution: {integrity: sha512-7eKNczxuxMsfMrCYYneR+Y4C3MnzFS6hb+D94vwaIZbP0cxXHaGxzyGmUE0e3C7fLTC9W1jNR0pZbeC+IeFt2A==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@moq/loc@0.1.2':
+    resolution: {integrity: sha512-7hqereQwKCf6JMtKPKskgcSJC3naLQbB5/FsArKRUTMlQIF/QRu3gcaYflW8qSXaHrKm3hmpl7ra/oPLm4F7GA==}
+
+  '@moq/msf@0.1.4':
+    resolution: {integrity: sha512-cdAcWz3lFCnAu44nf4zsugAp0X84N8w/o/b5rynPMB/1uelXCdQpcbnYUK4kZhq0co8lDM28oAUOGwyL9BjIXg==}
+
+  '@moq/net@0.1.9':
+    resolution: {integrity: sha512-S6qE57ZbUAd1+pem/BUMja2T/sKhXT5mjAqo063llbtIy5DOybe3XSjEhKGaLT+/GZVbISFAeTdnuohoeI7XYw==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@moq/publish@0.2.17':
+    resolution: {integrity: sha512-6qDoh9FxEN3ee/raNnmQ4mTpnbhqcrzAQzft97tPVxZRgzie8vtTlRZYuDobRIYbz6iQ4tlpWuy1Fuc1xuDS6w==}
+
+  '@moq/qmux@0.1.3':
+    resolution: {integrity: sha512-naGmMMOxCSMeLyEATrLiY9RGyeZENC4dHFVVNWNcA17LXE9NwM3aQrQY218xXypWahYIgIkl/ZCutIP2xHibgA==}
+
+  '@moq/signals@0.1.10':
+    resolution: {integrity: sha512-TSnQwcaywn/gIwC3UpwZbqYnXm2Zo8KZO6Y043jPiPnbnSlFWJVZ9TVdGAvQqrXGiaNihdcioF/0IEDABsfovw==}
+    peerDependencies:
+      '@types/react': ^19.2.17
+      react: ^19.0.0
+      solid-js: ^1.9.13
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      solid-js:
+        optional: true
+
+  '@moq/watch@0.2.19':
+    resolution: {integrity: sha512-vSNcRUyOzUArabfMljf+DTP5gnM/Z0lSuZM/hoszLWK88PdU+ddckHF90q1IGg3pJl7Ti26voQ6ayFhM8bKFWA==}
+
+  '@moq/web-socket-stream@0.1.0':
+    resolution: {integrity: sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ==}
 
   '@mswjs/interceptors@0.39.7':
     resolution: {integrity: sha512-sURvQbbKsq5f8INV54YJgJEdk8oxBanqkTiXXd33rKmofFCwZLhLRszPduMZ9TA9b8/1CHc/IJmOlBHJk2Q5AQ==}
@@ -1419,24 +1503,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.18':
     resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.18':
     resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.18':
     resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.18':
     resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
@@ -1496,6 +1584,11 @@ packages:
     resolution: {integrity: sha512-QmJTgh2rncP3APLwWbM9N/WYMip0a1biTXP7IJ/WZqx0VNuN7S8wbNl7mmzNIMyxReIaG7soBwVfB0sOd389tQ==}
     peerDependencies:
       '@pipecat-ai/client-js': ~1.6.0
+
+  '@pipecat-ai/moq-transport@0.1.0':
+    resolution: {integrity: sha512-bDuOyOx+wx/If3410VihaO+SEZ062hYBy7IjEj7APhRAmgj5qA6N5jCgF/AxyKs+70cEnhSP77pwsTMp2s/uMQ==}
+    peerDependencies:
+      '@pipecat-ai/client-js': ~1.13.0
 
   '@pipecat-ai/small-webrtc-transport@1.9.0':
     resolution: {integrity: sha512-7bfe+7Qcd/2CS1Lg6h3QDJOYtEZgZtFxJ9Atg6r8IhGw7fUzB4y7l9r1FFXbTxzpSFl9GvkFflXP2vuSCD8Uzw==}
@@ -2004,36 +2097,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.2':
     resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.2':
     resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.2':
     resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.2':
     resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.2':
     resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.2':
     resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
@@ -2098,66 +2197,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2256,6 +2368,16 @@ packages:
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
+  '@svta/cml-iso-bmff@1.0.2':
+    resolution: {integrity: sha512-c9UgY1z16zgvTEa6fS++9E9zxLuPtLJ4Dw5ebOgEDtwIw+PIhbh3URGXjv30tyDU2QQTXstI6U1q6h/Q4SkxGQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0':
+    resolution: {integrity: sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==}
+    engines: {node: '>=20'}
+
   '@swc/core-darwin-arm64@1.13.5':
     resolution: {integrity: sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==}
     engines: {node: '>=10'}
@@ -2279,24 +2401,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.5':
     resolution: {integrity: sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.5':
     resolution: {integrity: sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.5':
     resolution: {integrity: sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.5':
     resolution: {integrity: sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==}
@@ -2405,48 +2531,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.13':
     resolution: {integrity: sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -2749,6 +2883,9 @@ packages:
     peerDependencies:
       typescript: '*'
 
+  '@ungap/global-this@0.4.4':
+    resolution: {integrity: sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -2791,41 +2928,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2999,6 +3144,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -4530,48 +4678,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -5157,6 +5313,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  pako@3.0.1:
+    resolution: {integrity: sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6347,6 +6506,9 @@ packages:
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
     engines: {node: '>=12.20.0'}
@@ -7187,6 +7349,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@kixelated/libavjs-webcodecs-polyfill@0.5.5':
+    dependencies:
+      '@libav.js/types': 6.9.8
+      '@ungap/global-this': 0.4.4
+
   '@kurkle/color@0.3.4': {}
 
   '@ladle/react-context@1.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
@@ -7282,6 +7449,10 @@ snapshots:
     dependencies:
       '@lezer/common': 1.2.3
 
+  '@libav.js/types@6.9.8': {}
+
+  '@libav.js/variant-opus-af@6.9.8': {}
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1':
@@ -7319,6 +7490,214 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.1.16
       react: 19.2.1
+
+  '@moq/flate@0.1.1':
+    dependencies:
+      pako: 3.0.1
+
+  '@moq/hang@0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)':
+    dependencies:
+      '@kixelated/libavjs-webcodecs-polyfill': 0.5.5
+      '@libav.js/variant-opus-af': 6.9.8
+      '@moq/json': 0.2.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/loc': 0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+      '@svta/cml-iso-bmff': 1.0.2(@svta/cml-utils@1.5.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/hang@0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)':
+    dependencies:
+      '@kixelated/libavjs-webcodecs-polyfill': 0.5.5
+      '@libav.js/variant-opus-af': 6.9.8
+      '@moq/json': 0.2.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/loc': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+      '@svta/cml-iso-bmff': 1.0.2(@svta/cml-utils@1.5.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/json@0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/flate': 0.1.1
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/json@0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/flate': 0.1.1
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/json@0.2.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/flate': 0.1.1
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/json@0.2.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/flate': 0.1.1
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/loc@0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@moq/loc@0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@moq/msf@0.1.4(@types/react@19.1.11)(react@19.2.1)':
+    dependencies:
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/msf@0.1.4(@types/react@19.1.16)(react@19.2.1)':
+    dependencies:
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/net@0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/qmux': 0.1.3
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+      async-mutex: 0.5.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/net@0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/qmux': 0.1.3
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+      async-mutex: 0.5.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - solid-js
+
+  '@moq/publish@0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)
+      '@moq/json': 0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@moq/publish@0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)
+      '@moq/json': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@moq/qmux@0.1.3':
+    dependencies:
+      '@moq/web-socket-stream': 0.1.0
+
+  '@moq/signals@0.1.10(@types/react@19.1.11)(react@19.2.1)':
+    optionalDependencies:
+      '@types/react': 19.1.11
+      react: 19.2.1
+
+  '@moq/signals@0.1.10(@types/react@19.1.16)(react@19.2.1)':
+    optionalDependencies:
+      '@types/react': 19.1.16
+      react: 19.2.1
+
+  '@moq/watch@0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)
+      '@moq/json': 0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/msf': 0.1.4(@types/react@19.1.11)(react@19.2.1)
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@moq/watch@0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)
+      '@moq/json': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/msf': 0.1.4(@types/react@19.1.16)(react@19.2.1)
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@moq/web-socket-stream@0.1.0': {}
 
   '@mswjs/interceptors@0.39.7':
     dependencies:
@@ -7439,6 +7818,38 @@ snapshots:
     dependencies:
       '@daily-co/daily-js': 0.86.0
       '@pipecat-ai/client-js': 1.13.0
+
+  '@pipecat-ai/moq-transport@0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)
+      '@moq/json': 0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/publish': 0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
+      '@moq/watch': 0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
+      '@pipecat-ai/client-js': 1.13.0
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
+
+  '@pipecat-ai/moq-transport@0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
+    dependencies:
+      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)
+      '@moq/json': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/publish': 0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
+      '@moq/watch': 0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+      '@pipecat-ai/client-js': 1.13.0
+    transitivePeerDependencies:
+      - '@svta/cml-utils'
+      - '@types/react'
+      - react
+      - solid-js
+      - zod
 
   '@pipecat-ai/small-webrtc-transport@1.9.0(@pipecat-ai/client-js@1.13.0)':
     dependencies:
@@ -8456,6 +8867,12 @@ snapshots:
 
   '@stitches/core@1.2.8': {}
 
+  '@svta/cml-iso-bmff@1.0.2(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0': {}
+
   '@swc/core-darwin-arm64@1.13.5':
     optional: true
 
@@ -9116,6 +9533,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@ungap/global-this@0.4.4': {}
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -9384,6 +9803,10 @@ snapshots:
   astring@1.9.0: {}
 
   async-function@1.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -9952,8 +10375,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.34.0(jiti@2.6.1))
@@ -9972,8 +10395,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -9996,7 +10419,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10007,11 +10430,11 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10022,33 +10445,33 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10059,7 +10482,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10077,7 +10500,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10088,7 +10511,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12090,6 +12513,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@3.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -13456,6 +13881,8 @@ snapshots:
   zod@4.1.3: {}
 
   zod@4.3.5: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.8(@types/react@19.1.11)(react@19.2.1):
     optionalDependencies:


### PR DESCRIPTION
Part of MoQ transport addition: https://github.com/pipecat-ai/pipecat/pull/4629

depends on https://github.com/pipecat-ai/pipecat-client-web-transports/pull/139