### PR TITLE
Fix release-please workflow by pinning Claude model version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -144,6 +144,13 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pin an explicit model. Without this the action falls back to
+          # the CLI's built-in default, which was the retired
+          # `claude-sonnet-4-20250514` and made every run fail with a
+          # 404 not_found_error. `fallback_model` guards against the
+          # pinned model being unavailable on a future run.
+          model: "claude-sonnet-4-6"
+          fallback_model: "claude-sonnet-4-5"
           # NB: at v0.0.63 the action exposes discrete inputs rather than
           # the newer `claude_args` interface. Use `allowed_tools` /
           # `max_turns` directly — passing `claude_args` here is silently


### PR DESCRIPTION
## Summary
Updated the release-please GitHub Actions workflow to explicitly pin the Claude model version used by the `claude-code-base-action`, resolving failures caused by a retired model being used as the default fallback.

## Changes
- Added explicit `model: "claude-sonnet-4-6"` configuration to the anthropics/claude-code-base-action step
- Added `fallback_model: "claude-sonnet-4-5"` as a safety measure against future model unavailability
- Added explanatory comments documenting why the model pinning is necessary

## Details
The action was previously falling back to the CLI's built-in default model (`claude-sonnet-4-20250514`), which has been retired and caused every workflow run to fail with a 404 not_found_error. By explicitly pinning to a current model version with a fallback option, the workflow will now execute successfully and remain resilient to future model deprecations.

https://claude.ai/code/session_01Vs7FJMWNLRjnMo9qircGvh