### PR TITLE
fix(ci): handle no-op docs releases in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -276,15 +276,21 @@ jobs:
           # Strip the throwaway context dir before committing.
           rm -rf .release-context
           git add docs/content/docs
-          # `changed` covers two cases: the agent edited files in this
-          # run, or a merge with main brought in new commits. Either way
-          # we have something worth pushing.
-          if git diff --cached --quiet && [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$DOCS_BRANCH" 2>/dev/null || git rev-parse origin/main)" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Commit any documentation edits the agent made this run.
           if ! git diff --cached --quiet; then
             git commit -m "docs: update for v$NEXT_VERSION"
+          fi
+          # A docs PR is only meaningful when the branch actually differs
+          # from main. When a release has no documentable source changes
+          # (e.g. a dependency/security-only patch) the agent makes no
+          # edits, and after "Prepare docs branch" merges main in, the
+          # branch becomes identical to main. Pushing it and opening a PR
+          # then fails with "No commits between main and <branch>". Gate
+          # on the real diff against main rather than on the branch tip
+          # having moved, so the no-op case exits cleanly without a PR.
+          if git diff --quiet origin/main -- docs/content/docs; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           # Fast-forward push (the branch was either freshly created from
           # main, or extended on top of its own previous tip). No force


### PR DESCRIPTION
## Problem

After fixing the retired-model failure in #147, the `docs-update` job in the Release Please workflow still failed — on a second, separate bug. See [run 27622509472](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/27622509472/job/81675130976):

```
pull request create failed: GraphQL: No commits between main and docs/release-v0.11.1 (createPullRequest)
```

The model fix worked (the run used `claude-sonnet-4-6` and the agent completed), and the agent correctly concluded there was nothing to document for v0.11.1 (a dependency/security-only patch with zero `package/src/**` changes). The failure was in the workflow's plumbing afterward.

## Root cause

The "Commit and push docs updates" step computed its `changed` output from whether the **branch tip moved**, not whether the branch has **documentable changes**:

```sh
if git diff --cached --quiet && [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$DOCS_BRANCH" ...)" ]; then
  changed=false ...
```

For a release with no doc changes, the agent makes no edits, but "Prepare docs branch" merges `main` into the pre-existing docs branch, advancing `HEAD`. So `HEAD != origin/<docs-branch>`, the guard misfires, `changed=true`, and the job pushes a branch identical to `main` and then tries to open a PR with no diff — which GitHub rejects.

## Fix

Gate the push/PR on the real diff against `main` (`git diff origin/main -- docs/content/docs`) rather than on the branch tip moving. A no-op release now exits cleanly with `changed=false` and the PR step is skipped, leaving the job green. Releases that do touch documented source still diff against `main`, push, and open/update the docs PR as before.

## Verification

This only takes effect once on `main`. After merge, re-running [run 27622509472](https://github.com/pipecat-ai/voice-ui-kit/actions/runs/27622509472) should show the `docs-update` job succeeding with no docs PR created for v0.11.1.

https://claude.ai/code/session_01Vs7FJMWNLRjnMo9qircGvh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vs7FJMWNLRjnMo9qircGvh)_