### PR TITLE
fix: typo “occured” → “occurred” in error message

### DIFF
--- a/examples/02-components/src/app/components/App.tsx
+++ b/examples/02-components/src/app/components/App.tsx
@@ -19,7 +19,7 @@ export interface AppProps {
 export const App = ({ handleConnect, handleDisconnect, error }: AppProps) => {
   if (error) {
     return (
-      <ErrorCard error={error} title="An error occured connecting to agent." />
+      <ErrorCard error={error} title="An error occurred connecting to agent." />
     );
   }
 


### PR DESCRIPTION
Fixes a typo in a user-facing error message (“occured” → “occurred”).