### PR TITLE
feat: DTMF keypad support for the kit and Console template

### DIFF
--- a/examples/01-console/package.json
+++ b/examples/01-console/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@daily-co/daily-js": ">=0.84.0",
-    "@pipecat-ai/client-js": ">=1.8.0",
-    "@pipecat-ai/client-react": ">=1.4.0",
+    "@pipecat-ai/client-js": ">=1.13.0",
+    "@pipecat-ai/client-react": ">=1.8.0",
     "@pipecat-ai/daily-transport": ">=1.6.0",
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/voice-ui-kit": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   ],
   "dependencies": {
     "@daily-co/daily-js": "^0.85.0",
-    "@pipecat-ai/client-js": "^1.8.0",
-    "@pipecat-ai/client-react": "^1.4.0",
+    "@pipecat-ai/client-js": "^1.13.0",
+    "@pipecat-ai/client-react": "^1.8.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "tailwindcss": "^4.1.13"

--- a/package/package.json
+++ b/package/package.json
@@ -46,8 +46,8 @@
   ],
   "peerDependencies": {
     "@daily-co/daily-js": ">=0.84.0",
-    "@pipecat-ai/client-js": ">=1.8.0",
-    "@pipecat-ai/client-react": ">=1.4.0",
+    "@pipecat-ai/client-js": ">=1.13.0",
+    "@pipecat-ai/client-react": ">=1.8.0",
     "@pipecat-ai/daily-transport": ">=1.6.0",
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/websocket-transport": ">=1.6.2",
@@ -114,14 +114,15 @@
     "react-resizable-panels": "^3.0.6",
     "semver": "^7.6.3",
     "tailwind-merge": "^3.3.1",
+    "vaul": "^1.1.2",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@daily-co/daily-js": "^0.85.0",
     "@eslint/js": "^9.36.0",
     "@ladle/react": "^5.0.3",
-    "@pipecat-ai/client-js": "^1.8.0",
-    "@pipecat-ai/client-react": "^1.4.0",
+    "@pipecat-ai/client-js": "^1.13.0",
+    "@pipecat-ai/client-react": "^1.8.0",
     "@pipecat-ai/daily-transport": "^1.6.0",
     "@pipecat-ai/small-webrtc-transport": "^1.9.0",
     "@pipecat-ai/websocket-transport": "^1.6.2",

--- a/package/src/components/PipecatAppBase.tsx
+++ b/package/src/components/PipecatAppBase.tsx
@@ -321,7 +321,18 @@ export const PipecatAppBase: React.FC<PipecatBaseProps> = ({
   const renderedChildren =
     typeof children === "function" ? children(passedProps) : children;
   const clientProvider = (
-    <PipecatClientProvider client={client!}>
+    // client-react@1.8.0 ships a duplicated `PipecatClient` class declaration
+    // in its bundled types instead of re-exporting the one from client-js, so
+    // the client-js instance we hold isn't nominally assignable to the
+    // provider's `client` prop. Cast to the prop's declared type; the two are
+    // structurally identical. Remove once client-react re-exports the type.
+    <PipecatClientProvider
+      client={
+        client! as unknown as React.ComponentProps<
+          typeof PipecatClientProvider
+        >["client"]
+      }
+    >
       <>
         {renderedChildren}
         {!noAudioOutput && <BotAudioOutput />}

--- a/package/src/components/elements/DTMFKeypad.stories.tsx
+++ b/package/src/components/elements/DTMFKeypad.stories.tsx
@@ -1,0 +1,208 @@
+import { Card, CardContent } from "@/components/ui/card";
+import type { ButtonSize, ButtonVariant } from "@/components/ui/buttonVariants";
+import {
+  buttonSizeOptions,
+  buttonVariantOptions,
+} from "@/components/ui/buttonVariants";
+import type { Story, StoryDefault } from "@ladle/react";
+import { type DTMFButton, PipecatClient } from "@pipecat-ai/client-js";
+import { PipecatClientProvider } from "@pipecat-ai/client-react";
+import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
+import { type ComponentProps, useEffect, useState } from "react";
+import { DTMFKeypad, DTMFKeypadComponent } from "./DTMFKeypad";
+
+export default {
+  title: "Components / DTMF Keypad",
+  argTypes: {
+    variant: {
+      options: buttonVariantOptions,
+      control: { type: "select" },
+      defaultValue: "secondary",
+    },
+    size: {
+      options: buttonSizeOptions,
+      control: { type: "select" },
+      defaultValue: "lg",
+    },
+    disabled: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    noSubLabels: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    noToneFeedback: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+  },
+} satisfies StoryDefault;
+
+/**
+ * Headless keypad in immediate mode. Presses are collected into a local buffer
+ * so you can see the sequence that would be sent to the server.
+ */
+export const Default: Story<{
+  variant: ButtonVariant;
+  size: ButtonSize;
+  disabled: boolean;
+  noSubLabels: boolean;
+  noToneFeedback: boolean;
+}> = ({ variant, size, disabled, noSubLabels, noToneFeedback }) => {
+  const [sequence, setSequence] = useState("");
+
+  return (
+    <Card className="w-full max-w-xs">
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-2 font-mono text-sm min-h-6">
+          <span className="truncate">{sequence || " "}</span>
+          {sequence && (
+            <button
+              type="button"
+              className="text-xs opacity-60 hover:opacity-100"
+              onClick={() => setSequence("")}
+            >
+              clear
+            </button>
+          )}
+        </div>
+        <DTMFKeypadComponent
+          mode="immediate"
+          variant={variant}
+          size={size}
+          disabled={disabled}
+          noSubLabels={noSubLabels}
+          noToneFeedback={noToneFeedback}
+          onPress={(button: DTMFButton) => setSequence((s) => s + button)}
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+Default.args = {
+  variant: "secondary",
+  size: "lg",
+  disabled: false,
+  noSubLabels: false,
+  noToneFeedback: false,
+};
+
+Default.storyName = "Pure Component";
+
+/**
+ * Buffered mode. Presses accumulate in an editable field; pressing Send (or
+ * Enter) submits the whole sequence at once. Here we just log each submission.
+ */
+export const Buffered: Story<{
+  variant: ButtonVariant;
+  size: ButtonSize;
+  noSubLabels: boolean;
+  noToneFeedback: boolean;
+}> = ({ variant, size, noSubLabels, noToneFeedback }) => {
+  const [sent, setSent] = useState<string[]>([]);
+
+  return (
+    <Card className="w-full max-w-xs">
+      <CardContent className="flex flex-col gap-4">
+        <DTMFKeypadComponent
+          mode="buffered"
+          variant={variant}
+          size={size}
+          noSubLabels={noSubLabels}
+          noToneFeedback={noToneFeedback}
+          onSend={(sequence) => setSent((s) => [...s, sequence])}
+        />
+        {sent.length > 0 && (
+          <div className="font-mono text-xs opacity-70">
+            sent: {sent.join(", ")}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+Buffered.args = {
+  variant: "secondary",
+  size: "lg",
+  noSubLabels: false,
+  noToneFeedback: false,
+};
+
+Buffered.storyName = "Buffered (Pure)";
+
+/**
+ * Connected keypad. Requires a live Pipecat client; the keypad is disabled
+ * until the transport is connected. In buffered mode (default) the sequence is
+ * sent on submit; in immediate mode each press sends its tone via `sendDTMF`.
+ */
+export const Connected: Story<{
+  mode: "immediate" | "buffered";
+  variant: ButtonVariant;
+  size: ButtonSize;
+  noSubLabels: boolean;
+  noToneFeedback: boolean;
+}> = ({ mode, variant, size, noSubLabels, noToneFeedback }) => (
+  <Card className="w-full max-w-xs">
+    <CardContent>
+      <DTMFKeypad
+        mode={mode}
+        variant={variant}
+        size={size}
+        noSubLabels={noSubLabels}
+        noToneFeedback={noToneFeedback}
+      />
+    </CardContent>
+  </Card>
+);
+
+Connected.args = {
+  mode: "buffered",
+  variant: "secondary",
+  size: "lg",
+  noToneFeedback: false,
+};
+
+Connected.argTypes = {
+  mode: {
+    options: ["immediate", "buffered"],
+    control: { type: "radio" },
+    defaultValue: "buffered",
+  },
+};
+
+Connected.decorators = [
+  (Component) => {
+    const [client, setClient] = useState<PipecatClient | null>(null);
+
+    useEffect(() => {
+      const client = new PipecatClient({
+        transport: new SmallWebRTCTransport(),
+      });
+      setClient(client);
+    }, []);
+
+    if (!client) {
+      return <div>Loading...</div>;
+    }
+
+    // client-react@1.8.0 ships a duplicated, non-assignable PipecatClient type
+    // instead of re-exporting client-js's; cast as in PipecatAppBase. Remove
+    // once client-react re-exports the type.
+    return (
+      <PipecatClientProvider
+        client={
+          client as unknown as ComponentProps<
+            typeof PipecatClientProvider
+          >["client"]
+        }
+      >
+        <Component />
+      </PipecatClientProvider>
+    );
+  },
+];
+
+Connected.storyName = "Connected";

--- a/package/src/components/elements/DTMFKeypad.tsx
+++ b/package/src/components/elements/DTMFKeypad.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  type ButtonSize,
+  type ButtonVariant,
+} from "@/components/ui/buttonVariants";
+import { Input } from "@/components/ui/input";
+import { usePipecatConnectionState } from "@/hooks";
+import { cn } from "@/lib/utils";
+import { type DTMFButton } from "@pipecat-ai/client-js";
+import { useDTMF } from "@pipecat-ai/client-react";
+import { DeleteIcon, PhoneIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Ordered list of the twelve DTMF keys as they appear on a standard telephone
+ * keypad, along with the letters/symbols traditionally printed beneath each
+ * digit. Rendered row by row into a 3-column grid.
+ */
+const DTMF_KEYS: { value: DTMFButton; sub?: string }[] = [
+  { value: "1" },
+  { value: "2", sub: "ABC" },
+  { value: "3", sub: "DEF" },
+  { value: "4", sub: "GHI" },
+  { value: "5", sub: "JKL" },
+  { value: "6", sub: "MNO" },
+  { value: "7", sub: "PQRS" },
+  { value: "8", sub: "TUV" },
+  { value: "9", sub: "WXYZ" },
+  { value: "*" },
+  { value: "0", sub: "+" },
+  { value: "#" },
+];
+
+/** Keep only characters that are valid in a DTMF sequence. */
+const sanitizeDTMF = (value: string): string => value.replace(/[^0-9*#]/g, "");
+
+/**
+ * The (row, column) frequency pair that defines each key's dual tone, per the
+ * standard DTMF layout. Synthesizing from these keeps the kit free of bundled
+ * audio assets.
+ */
+const DTMF_FREQUENCIES: Record<DTMFButton, [number, number]> = {
+  "1": [697, 1209],
+  "2": [697, 1336],
+  "3": [697, 1477],
+  "4": [770, 1209],
+  "5": [770, 1336],
+  "6": [770, 1477],
+  "7": [852, 1209],
+  "8": [852, 1336],
+  "9": [852, 1477],
+  "*": [941, 1209],
+  "0": [941, 1336],
+  "#": [941, 1477],
+};
+
+/** Length of the press feedback tone, in seconds. */
+const TONE_DURATION = 0.12;
+/**
+ * Default peak gain of the feedback tone. Deliberately quiet: it plays over a
+ * live call. Override with the `toneVolume` prop.
+ */
+const DEFAULT_TONE_VOLUME = 0.15;
+/** Attack/release ramp length, in seconds. Without it the tone clicks. */
+const TONE_RAMP = 0.01;
+
+/**
+ * Returns a function that plays a key's DTMF tone locally as press feedback.
+ *
+ * This is a cosmetic sidetone only: the actual signalling happens over the
+ * transport via `sendDTMF`. The tone is synthesized from the two frequencies
+ * that define the key rather than played from a bundled audio file.
+ */
+const useDTMFTone = (enabled: boolean, volume: number) => {
+  const contextRef = useRef<AudioContext | null>(null);
+  // Clamped so a stray prop value can't invert the waveform or blast the tone
+  // out at many times the intended level.
+  const peakGain = Math.min(Math.max(volume, 0), 1);
+
+  useEffect(
+    () => () => {
+      void contextRef.current?.close();
+      contextRef.current = null;
+    },
+    [],
+  );
+
+  return useCallback(
+    (key: DTMFButton) => {
+      if (
+        !enabled ||
+        peakGain <= 0 ||
+        typeof window === "undefined" ||
+        !window.AudioContext
+      ) {
+        return;
+      }
+      // Created lazily on first press so it's tied to a user gesture (autoplay
+      // policy) and never constructed during SSR, then reused across presses.
+      const context = (contextRef.current ??= new window.AudioContext());
+      if (context.state === "suspended") void context.resume();
+
+      const now = context.currentTime;
+      const gain = context.createGain();
+      gain.connect(context.destination);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(peakGain, now + TONE_RAMP);
+      gain.gain.setValueAtTime(peakGain, now + TONE_DURATION - TONE_RAMP);
+      gain.gain.linearRampToValueAtTime(0, now + TONE_DURATION);
+
+      const oscillators = DTMF_FREQUENCIES[key].map((frequency) => {
+        const oscillator = context.createOscillator();
+        oscillator.type = "sine";
+        oscillator.frequency.setValueAtTime(frequency, now);
+        oscillator.connect(gain);
+        oscillator.start(now);
+        oscillator.stop(now + TONE_DURATION);
+        return oscillator;
+      });
+
+      oscillators[oscillators.length - 1].onended = () => {
+        oscillators.forEach((oscillator) => oscillator.disconnect());
+        gain.disconnect();
+      };
+    },
+    [enabled, peakGain],
+  );
+};
+
+/**
+ * Behavior of the keypad:
+ * - `"buffered"` (default): key presses accumulate in an editable field and are
+ *   sent as a single sequence when the user submits, so a mistyped digit can be
+ *   corrected before anything is transmitted (natural for entering a full
+ *   number/extension before dialing).
+ * - `"immediate"`: each key press sends that tone right away (natural for
+ *   navigating live IVR menus, where each key is answered on its own).
+ */
+export type DTMFKeypadMode = "immediate" | "buffered";
+
+/**
+ * Base props shared by the headless and connected keypad components.
+ */
+export interface DTMFKeypadBaseProps {
+  /** How presses are dispatched. Default: "buffered" */
+  mode?: DTMFKeypadMode;
+  /** Visual style variant for the keypad buttons. Default: "secondary" */
+  variant?: ButtonVariant;
+  /** Size of the keypad buttons. Default: "lg" */
+  size?: ButtonSize;
+  /** Disables the entire keypad. */
+  disabled?: boolean;
+  /** Hides the letters/symbols printed beneath each digit. Default: false */
+  noSubLabels?: boolean;
+  /**
+   * Disables the audible tone played on each key press. The tone is local
+   * press feedback only and is not what signals the digit to the server.
+   * Default: false
+   */
+  noToneFeedback?: boolean;
+  /**
+   * Peak volume of the key press tone, from 0 (silent) to 1 (full scale).
+   * Values outside that range are clamped. Defaults to 0.15, kept low because
+   * the tone plays over a live call.
+   */
+  toneVolume?: number;
+  /** Additional props to pass to every keypad button. */
+  buttonProps?: Partial<React.ComponentProps<typeof Button>>;
+  /** Placeholder for the input field (buffered mode). */
+  placeholder?: string;
+  /** Label for the send button (buffered mode). Default: "Send" */
+  sendLabel?: string;
+  /** Custom CSS classes for different parts of the component. */
+  classNames?: {
+    /** CSS classes for the outer wrapper. */
+    root?: string;
+    /** CSS classes for the grid container. */
+    container?: string;
+    /** CSS classes for each keypad button. */
+    button?: string;
+    /** CSS classes for the digit label. */
+    label?: string;
+    /** CSS classes for the sub-label (letters/symbols). */
+    subLabel?: string;
+    /** CSS classes for the input row (buffered mode). */
+    inputRow?: string;
+    /** CSS classes for the input field (buffered mode). */
+    input?: string;
+    /** CSS classes for the backspace button (buffered mode). */
+    backspace?: string;
+    /** CSS classes for the send button (buffered mode). */
+    sendButton?: string;
+  };
+}
+
+/**
+ * Props for the headless {@link DTMFKeypadComponent}.
+ */
+export interface DTMFKeypadComponentProps extends DTMFKeypadBaseProps {
+  /** Called with each key as it is pressed (fires in both modes). */
+  onPress?: (button: DTMFButton) => void;
+  /** Called with the full sequence when submitted (buffered mode). */
+  onSend?: (sequence: string) => void;
+  /** Controlled buffer value (buffered mode). */
+  value?: string;
+  /** Default buffer value when uncontrolled (buffered mode). Default: "" */
+  defaultValue?: string;
+  /** Called whenever the buffer changes (buffered mode). */
+  onValueChange?: (value: string) => void;
+}
+
+/**
+ * Headless DTMF keypad. Renders a standard 12-key telephone keypad. In
+ * `"buffered"` mode (default) presses accumulate in an editable field and
+ * `onSend` fires with the full sequence on submit; in `"immediate"` mode each
+ * press invokes `onPress` only. Holds no client state and can be used with any
+ * framework or state management solution.
+ *
+ * @example
+ * ```tsx
+ * // buffered (default)
+ * <DTMFKeypadComponent onSend={(seq) => console.log(seq)} />
+ * // immediate
+ * <DTMFKeypadComponent mode="immediate" onPress={(key) => console.log(key)} />
+ * ```
+ */
+export const DTMFKeypadComponent: React.FC<DTMFKeypadComponentProps> = ({
+  mode = "buffered",
+  variant = "secondary",
+  size = "lg",
+  disabled = false,
+  noSubLabels = false,
+  noToneFeedback = false,
+  toneVolume = DEFAULT_TONE_VOLUME,
+  buttonProps = {},
+  placeholder = "Enter digits",
+  sendLabel = "Send",
+  classNames = {},
+  onPress,
+  onSend,
+  value,
+  defaultValue,
+  onValueChange,
+}) => {
+  const buffered = mode === "buffered";
+
+  // Controlled/uncontrolled buffer for buffered mode.
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState(defaultValue ?? "");
+  const buffer = isControlled ? (value ?? "") : internalValue;
+
+  const setBuffer = useCallback(
+    (next: string) => {
+      if (!isControlled) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const playTone = useDTMFTone(!noToneFeedback, toneVolume);
+
+  const handlePress = useCallback(
+    (key: DTMFButton) => {
+      playTone(key);
+      onPress?.(key);
+      if (buffered) setBuffer(buffer + key);
+    },
+    [buffered, buffer, onPress, setBuffer, playTone],
+  );
+
+  const handleSend = useCallback(() => {
+    // Sanitize at send time too: a controlled `value`/`defaultValue` bypasses
+    // the input's onChange sanitization, so this guarantees the emitted
+    // sequence only ever contains valid DTMF characters.
+    const sequence = sanitizeDTMF(buffer);
+    if (!sequence) return;
+    onSend?.(sequence);
+    setBuffer("");
+  }, [buffer, onSend, setBuffer]);
+
+  const grid = (
+    <div className={cn("grid grid-cols-3 gap-2", classNames.container)}>
+      {DTMF_KEYS.map(({ value: key, sub }) => (
+        <Button
+          key={key}
+          variant={variant}
+          size={size}
+          aria-label={`DTMF ${key}`}
+          {...buttonProps}
+          // Force internal behavior after the spread so consumer buttonProps
+          // can't silently clobber it: keypad keys must stay non-submitting
+          // (type="button"), the press handler must run, and buttonProps must
+          // not re-enable the keypad while it's gated (e.g. disconnected).
+          // Consumers can still add an onClick or further disable.
+          type="button"
+          disabled={disabled || buttonProps.disabled}
+          onClick={(e) => {
+            buttonProps.onClick?.(e);
+            handlePress(key);
+          }}
+          className={cn(
+            "flex flex-col items-center justify-center gap-0 tabular-nums",
+            classNames.button,
+            buttonProps.className,
+          )}
+        >
+          <span className={cn("text-base font-semibold", classNames.label)}>
+            {key}
+          </span>
+          {!noSubLabels && (
+            <span
+              className={cn(
+                "h-2.5 text-[0.6rem] leading-none tracking-widest opacity-60",
+                classNames.subLabel,
+              )}
+            >
+              {sub ?? ""}
+            </span>
+          )}
+        </Button>
+      ))}
+    </div>
+  );
+
+  if (!buffered) return grid;
+
+  return (
+    <div className={cn("flex flex-col gap-2", classNames.root)}>
+      <div className={cn("flex items-center gap-2", classNames.inputRow)}>
+        <Input
+          value={buffer}
+          onChange={(e) => setBuffer(sanitizeDTMF(e.target.value))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              // Prevent the native implicit form submit if the keypad is
+              // embedded in a <form>; Enter should only dispatch the sequence.
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          // Suppress the native virtual keyboard on touch devices: the
+          // on-screen keypad is the intended input method. Typing/paste on
+          // desktop still works.
+          inputMode="none"
+          aria-label="DTMF sequence"
+          className={cn(
+            "flex-1 tracking-widest tabular-nums",
+            classNames.input,
+          )}
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          size={size}
+          isIcon
+          disabled={disabled || !buffer}
+          aria-label="Delete last digit"
+          onClick={() => setBuffer(buffer.slice(0, -1))}
+          className={cn(classNames.backspace)}
+        >
+          <DeleteIcon />
+        </Button>
+      </div>
+      {grid}
+      <Button
+        type="button"
+        variant={variant}
+        size={size}
+        isFullWidth
+        disabled={disabled || !buffer}
+        onClick={handleSend}
+        className={cn(classNames.sendButton)}
+      >
+        <PhoneIcon />
+        {sendLabel}
+      </Button>
+    </div>
+  );
+};
+
+/**
+ * Props for the connected {@link DTMFKeypad}.
+ */
+export interface DTMFKeypadProps extends DTMFKeypadBaseProps {
+  /** Called with each key as it is pressed (fires in both modes). */
+  onPress?: (button: DTMFButton) => void;
+  /** Controlled buffer value (buffered mode). */
+  value?: string;
+  /** Default buffer value when uncontrolled (buffered mode). */
+  defaultValue?: string;
+  /** Called whenever the buffer changes (buffered mode). */
+  onValueChange?: (value: string) => void;
+  /** Called after tone(s) are successfully sent. */
+  onToneSent?: (sequence: string) => void;
+  /**
+   * Called if sending fails. `sendDTMF` throws when the transport isn't ready
+   * or the connected bot doesn't support DTMF (RTVI protocol < 2.0.0); the
+   * error is caught and forwarded here instead of surfacing uncaught.
+   */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Connected DTMFKeypad that integrates with the Pipecat Client SDK.
+ *
+ * In `"buffered"` mode (default) the entered sequence is sent as one `sendDTMF`
+ * call on submit, so a mistyped digit can be corrected before anything is
+ * transmitted; in `"immediate"` mode each key press sends that tone right away,
+ * which suits navigating a live IVR menu. The keypad is disabled until the
+ * client is connected, since tones can only be sent once the transport is
+ * ready. Send failures are caught and reported via `onError` rather than
+ * thrown.
+ *
+ * Must be used within a `PipecatClientProvider` context.
+ *
+ * @example
+ * ```tsx
+ * <DTMFKeypad onToneSent={(seq) => console.log("sent", seq)} />
+ * ```
+ */
+export const DTMFKeypad: React.FC<DTMFKeypadProps> = ({
+  mode = "buffered",
+  disabled,
+  onPress,
+  onToneSent,
+  onError,
+  ...props
+}) => {
+  const { sendTone } = useDTMF();
+  const { isConnected } = usePipecatConnectionState();
+
+  const send = useCallback(
+    (sequence: string) => {
+      try {
+        sendTone(sequence);
+        onToneSent?.(sequence);
+      } catch (error) {
+        onError?.(error);
+      }
+    },
+    [sendTone, onToneSent, onError],
+  );
+
+  return (
+    <DTMFKeypadComponent
+      mode={mode}
+      disabled={disabled || !isConnected}
+      onPress={(button) => {
+        onPress?.(button);
+        if (mode === "immediate") send(button);
+      }}
+      onSend={mode === "buffered" ? (sequence) => send(sequence) : undefined}
+      {...props}
+    />
+  );
+};
+
+export default DTMFKeypad;

--- a/package/src/components/elements/DeviceSelect.stories.tsx
+++ b/package/src/components/elements/DeviceSelect.stories.tsx
@@ -4,7 +4,7 @@ import type { Story, StoryDefault } from "@ladle/react";
 import { PipecatClient } from "@pipecat-ai/client-js";
 import { PipecatClientProvider } from "@pipecat-ai/client-react";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
-import { useEffect, useState } from "react";
+import { type ComponentProps, useEffect, useState } from "react";
 import { DeviceSelect, DeviceSelectComponent } from "./DeviceSelect";
 
 const mockDevices: MediaDeviceInfo[] = [
@@ -91,8 +91,15 @@ Connected.decorators = [
       return <div>Loading...</div>;
     }
 
+    // client-react@1.8.0 dts bug: cast as in PipecatAppBase.
     return (
-      <PipecatClientProvider client={client!}>
+      <PipecatClientProvider
+        client={
+          client! as unknown as ComponentProps<
+            typeof PipecatClientProvider
+          >["client"]
+        }
+      >
         <Component />
       </PipecatClientProvider>
     );

--- a/package/src/components/elements/SessionInfo.tsx
+++ b/package/src/components/elements/SessionInfo.tsx
@@ -40,9 +40,11 @@ export const SessionInfo: React.FC<Props> = ({
   if (client && "dailyCallClient" in client.transport) {
     transportTypeName = `Daily (v${Daily.version()})`;
   } else if (
-    // @ts-expect-error - __proto__ not typed
-    client?.transport.__proto__.constructor.SERVICE_NAME ===
-    "small-webrtc-transport"
+    (
+      client?.transport as unknown as {
+        __proto__: { constructor: { SERVICE_NAME?: string } };
+      } | null
+    )?.__proto__.constructor.SERVICE_NAME === "small-webrtc-transport"
   ) {
     transportTypeName = "Small WebRTC";
   }

--- a/package/src/components/elements/TextInput.stories.tsx
+++ b/package/src/components/elements/TextInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@pipecat-ai/client-react";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
 import { SendIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ComponentProps, useEffect, useState } from "react";
 import { TextInput, TextInputComponent } from "./TextInput";
 
 export default {
@@ -74,7 +74,14 @@ Pipecat.decorators = [
 
     return (
       <div>
-        <PipecatClientProvider client={client!}>
+        {/* client-react@1.8.0 dts bug: cast as in PipecatAppBase. */}
+        <PipecatClientProvider
+          client={
+            client! as unknown as ComponentProps<
+              typeof PipecatClientProvider
+            >["client"]
+          }
+        >
           <Component />
           <PipecatClientAudio />
         </PipecatClientProvider>

--- a/package/src/components/elements/UserAudioControl.stories.tsx
+++ b/package/src/components/elements/UserAudioControl.stories.tsx
@@ -15,7 +15,7 @@ import {
   PipecatClientProvider,
 } from "@pipecat-ai/client-react";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
-import { useEffect, useState } from "react";
+import { type ComponentProps, useEffect, useState } from "react";
 import UserAudioControl, { UserAudioComponent } from "./UserAudioControl";
 
 export default {
@@ -317,7 +317,14 @@ Connected.decorators = [
 
     return (
       <div>
-        <PipecatClientProvider client={client!}>
+        {/* client-react@1.8.0 dts bug: cast as in PipecatAppBase. */}
+        <PipecatClientProvider
+          client={
+            client! as unknown as ComponentProps<
+              typeof PipecatClientProvider
+            >["client"]
+          }
+        >
           <Component />
         </PipecatClientProvider>
       </div>

--- a/package/src/components/elements/UserVideoControl.stories.tsx
+++ b/package/src/components/elements/UserVideoControl.stories.tsx
@@ -15,7 +15,7 @@ import {
   PipecatClientProvider,
 } from "@pipecat-ai/client-react";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
-import { useEffect, useState } from "react";
+import { type ComponentProps, useEffect, useState } from "react";
 import UserVideoControl, { UserVideoComponent } from "./UserVideoControl";
 
 export default {
@@ -242,7 +242,14 @@ Connected.decorators = [
 
     return (
       <div>
-        <PipecatClientProvider client={client!}>
+        {/* client-react@1.8.0 dts bug: cast as in PipecatAppBase. */}
+        <PipecatClientProvider
+          client={
+            client! as unknown as ComponentProps<
+              typeof PipecatClientProvider
+            >["client"]
+          }
+        >
           <Component />
         </PipecatClientProvider>
       </div>

--- a/package/src/components/elements/index.ts
+++ b/package/src/components/elements/index.ts
@@ -6,6 +6,7 @@ export * from "./ControlBar";
 export * from "./Conversation";
 export * from "./CopyText";
 export * from "./DataList";
+export * from "./DTMFKeypad";
 export * from "./DeviceDropDown";
 export * from "./DeviceSelect";
 export * from "./FunctionCallContent";

--- a/package/src/components/ui/drawer.tsx
+++ b/package/src/components/ui/drawer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { getPipecatUIContainer } from "@/lib/dom";
+import { cn } from "@/lib/utils";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return (
+    <DrawerPrimitive.Portal
+      data-slot="drawer-portal"
+      container={getPipecatUIContainer()}
+      {...props}
+    />
+  );
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          // bottom (default)
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-panel data-[vaul-drawer-direction=bottom]:border-t",
+          // top
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-panel data-[vaul-drawer-direction=top]:border-b",
+          // right
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          // left
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-1.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/package/src/components/ui/index.ts
+++ b/package/src/components/ui/index.ts
@@ -7,6 +7,7 @@ export * from "./card";
 export * from "./collapsible";
 export * from "./container";
 export * from "./divider";
+export * from "./drawer";
 export * from "./dropdown-menu";
 export * from "./error";
 export * from "./input";

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -11,6 +11,7 @@ export {
   /** @deprecated Use `usePipecatConversation` instead. This alias will be removed in a future major release. */
   usePipecatConversation as useConversation,
 } from "@pipecat-ai/client-react";
+export { useDTMF } from "@pipecat-ai/client-react";
 export { usePipecatEventStream } from "./usePipecatEventStream";
 export type {
   PipecatEventGroup,

--- a/package/src/templates/Console/KeypadToggle.tsx
+++ b/package/src/templates/Console/KeypadToggle.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  DTMFKeypad,
+  type DTMFKeypadMode,
+} from "@/components/elements/DTMFKeypad";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { PhoneIcon } from "lucide-react";
+
+/**
+ * Header control that reveals the DTMF keypad on demand.
+ *
+ * Uses a popover anchored to the phone icon on desktop (sm+) and a bottom
+ * drawer on mobile, so the keypad stays out of the way until the user needs
+ * to send tones. Rendering both and toggling visibility with Tailwind's `sm:`
+ * breakpoint mirrors how the Console switches between its desktop and mobile
+ * layouts.
+ */
+export const KeypadToggle = ({
+  mode = "buffered",
+}: {
+  /** How the keypad dispatches presses. Default: "buffered" */
+  mode?: DTMFKeypadMode;
+}) => {
+  const trigger = (
+    <Button variant="ghost" isIcon aria-label="Open keypad">
+      <PhoneIcon />
+    </Button>
+  );
+
+  return (
+    <>
+      {/* Desktop: popover anchored to the header icon */}
+      <div className="hidden sm:block">
+        <Popover>
+          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+          <PopoverContent align="end" side="bottom" className="w-auto">
+            <DTMFKeypad mode={mode} />
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {/* Mobile: bottom drawer */}
+      <div className="sm:hidden">
+        <Drawer>
+          <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle>Keypad</DrawerTitle>
+              <DrawerDescription className="sr-only">
+                Send DTMF tones to the connected bot.
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="mx-auto w-full max-w-xs p-4 pt-0">
+              <DTMFKeypad mode={mode} />
+            </div>
+          </DrawerContent>
+        </Drawer>
+      </div>
+    </>
+  );
+};
+
+export default KeypadToggle;

--- a/package/src/templates/Console/index.tsx
+++ b/package/src/templates/Console/index.tsx
@@ -65,6 +65,8 @@ import {
 } from "lucide-react";
 import { type ImperativePanelHandle } from "react-resizable-panels";
 import React, { memo, useEffect, useRef, useState } from "react";
+import { type DTMFKeypadMode } from "@/components/elements/DTMFKeypad";
+import { KeypadToggle } from "./KeypadToggle";
 import { SmallWebRTCCodecSetter } from "./SmallWebRTCCodecSetter";
 import UserScreenControl from "../../components/elements/UserScreenControl";
 
@@ -80,6 +82,16 @@ export interface ConsoleTemplateProps
   noUserVideo?: boolean;
   /** Disables user screen control entirely. Default: false */
   noScreenControl?: boolean;
+  /** Disables the DTMF keypad entirely. Default: false */
+  noDTMF?: boolean;
+  /**
+   * How the DTMF keypad dispatches presses.
+   * - "buffered": digits accumulate in an editable field and are sent together,
+   *   so a mistyped digit can be corrected before anything is sent (default)
+   * - "immediate": each key sends its tone right away, which suits navigating
+   *   a live IVR menu
+   */
+  keypadMode?: DTMFKeypadMode;
   /** Disables text input in the conversation. Default: false */
   noTextInput?: boolean;
   /** Disables audio output for the bot. Default: false */
@@ -312,6 +324,8 @@ const ConsoleUI = ({
   noUserAudio = false,
   noUserVideo = false,
   noScreenControl = false,
+  noDTMF = false,
+  keypadMode = "buffered",
   noTextInput = false,
   noBotAudio = false,
   noBotAudioControls = false,
@@ -420,6 +434,7 @@ const ConsoleUI = ({
           <strong className="hidden sm:block text-center">{titleText}</strong>
           <div className="flex items-center justify-end gap-2 sm:gap-3 xl:gap-6">
             <div className="flex items-center gap-1">
+              {!noDTMF && <KeypadToggle mode={keypadMode} />}
               {!noThemeSwitch && <ThemeModeToggle />}
               <Button
                 className="hidden sm:flex"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,11 +43,11 @@ importers:
         specifier: ^0.85.0
         version: 0.85.0
       '@pipecat-ai/client-js':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.13.0
+        version: 1.13.0
       '@pipecat-ai/client-react':
-        specifier: ^1.4.0
-        version: 1.4.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.8.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^1.8.0
+        version: 1.8.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.13.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -96,7 +96,7 @@ importers:
         version: 2.20.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@pipecat-ai/small-webrtc-transport':
         specifier: ^1.9.0
-        version: 1.9.0(@pipecat-ai/client-js@1.8.0)
+        version: 1.9.0(@pipecat-ai/client-js@1.13.0)
       '@pipecat-ai/voice-ui-kit':
         specifier: workspace:*
         version: link:../package
@@ -174,23 +174,23 @@ importers:
         specifier: '>=0.84.0'
         version: 0.85.0
       '@pipecat-ai/client-js':
-        specifier: '>=1.8.0'
-        version: 1.8.0
+        specifier: '>=1.13.0'
+        version: 1.13.0
       '@pipecat-ai/client-react':
-        specifier: '>=1.4.0'
-        version: 1.4.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.8.0)(@types/react@19.1.11)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: '>=1.8.0'
+        version: 1.8.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.13.0)(@types/react@19.1.11)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@pipecat-ai/daily-transport':
         specifier: '>=1.6.0'
-        version: 1.6.0(@pipecat-ai/client-js@1.8.0)
+        version: 1.6.0(@pipecat-ai/client-js@1.13.0)
       '@pipecat-ai/small-webrtc-transport':
         specifier: '>=1.9.0'
-        version: 1.9.0(@pipecat-ai/client-js@1.8.0)
+        version: 1.9.0(@pipecat-ai/client-js@1.13.0)
       '@pipecat-ai/voice-ui-kit':
         specifier: workspace:*
         version: link:../../package
       '@pipecat-ai/websocket-transport':
         specifier: '>=1.6.2'
-        version: 1.6.2(@pipecat-ai/client-js@1.8.0)
+        version: 1.6.2(@pipecat-ai/client-js@1.13.0)
       next:
         specifier: 15.5.18
         version: 15.5.18(@babel/core@7.29.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -490,6 +490,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.1.16)(react@19.2.1)
@@ -504,20 +507,20 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(@types/node@22.18.8)(@types/react@19.1.16)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tsx@4.20.5)(typescript@5.8.3)(yaml@2.8.3)
       '@pipecat-ai/client-js':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.13.0
+        version: 1.13.0
       '@pipecat-ai/client-react':
-        specifier: ^1.4.0
-        version: 1.4.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.8.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^1.8.0
+        version: 1.8.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.13.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@pipecat-ai/daily-transport':
         specifier: ^1.6.0
-        version: 1.6.0(@pipecat-ai/client-js@1.8.0)
+        version: 1.6.0(@pipecat-ai/client-js@1.13.0)
       '@pipecat-ai/small-webrtc-transport':
         specifier: ^1.9.0
-        version: 1.9.0(@pipecat-ai/client-js@1.8.0)
+        version: 1.9.0(@pipecat-ai/client-js@1.13.0)
       '@pipecat-ai/websocket-transport':
         specifier: ^1.6.2
-        version: 1.6.2(@pipecat-ai/client-js@1.8.0)
+        version: 1.6.2(@pipecat-ai/client-js@1.13.0)
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.1.13(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.5)(yaml@2.8.3))
@@ -1479,11 +1482,11 @@ packages:
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
-  '@pipecat-ai/client-js@1.8.0':
-    resolution: {integrity: sha512-MrrKlIMHbcAzVz6SU5JHQFWxbr3iDKCiCmBj4SnBisL/ruz54J4pYf61Y5IP8yoUzjYTX9+NYOw/ADKp2NV5nQ==}
+  '@pipecat-ai/client-js@1.13.0':
+    resolution: {integrity: sha512-Gep0ji+3Qxo8rm10nnfsS7xhpCUgr40ZNwx8fLroKhW/Cz4eAHjbdxmfnUPNklGBUqcEwEgyZchrfDN2kMCisw==}
 
-  '@pipecat-ai/client-react@1.4.0':
-    resolution: {integrity: sha512-zORvbJZ0y9UIWYWUu4XDFI1lnuKyXGW7INaXYrmUDmFCI6wt3gcKsG/2px4DxKsxRoA4/HAz+i0/HHoxsaeG/A==}
+  '@pipecat-ai/client-react@1.8.0':
+    resolution: {integrity: sha512-3js26U7ZPDJhyTzfh+CQ7CrAQNDApDtNRJBoNoXsIGStBa/4OG1oYjvTeQ12yBKpKhph407J4r9OoRgSTGXdcQ==}
     peerDependencies:
       '@pipecat-ai/client-js': '*'
       react: '>=18'
@@ -6077,6 +6080,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -6084,6 +6091,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -7391,18 +7404,18 @@ snapshots:
 
   '@oxc-project/types@0.137.0': {}
 
-  '@pipecat-ai/client-js@1.8.0':
+  '@pipecat-ai/client-js@1.13.0':
     dependencies:
       '@types/events': 3.0.3
       bowser: 2.12.1
       clone-deep: 4.0.1
       events: 3.3.0
       typed-emitter: 2.1.0
-      uuid: 14.0.0
+      uuid: 11.1.1
 
-  '@pipecat-ai/client-react@1.4.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.8.0)(@types/react@19.1.11)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@pipecat-ai/client-react@1.8.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.13.0)(@types/react@19.1.11)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@pipecat-ai/client-js': 1.8.0
+      '@pipecat-ai/client-js': 1.13.0
       jotai: 2.18.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.1.11)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -7411,9 +7424,9 @@ snapshots:
       - '@babel/template'
       - '@types/react'
 
-  '@pipecat-ai/client-react@1.4.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.8.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@pipecat-ai/client-react@1.8.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.13.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@pipecat-ai/client-js': 1.8.0
+      '@pipecat-ai/client-js': 1.13.0
       jotai: 2.18.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.1.16)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -7422,22 +7435,22 @@ snapshots:
       - '@babel/template'
       - '@types/react'
 
-  '@pipecat-ai/daily-transport@1.6.0(@pipecat-ai/client-js@1.8.0)':
+  '@pipecat-ai/daily-transport@1.6.0(@pipecat-ai/client-js@1.13.0)':
     dependencies:
       '@daily-co/daily-js': 0.86.0
-      '@pipecat-ai/client-js': 1.8.0
+      '@pipecat-ai/client-js': 1.13.0
 
-  '@pipecat-ai/small-webrtc-transport@1.9.0(@pipecat-ai/client-js@1.8.0)':
+  '@pipecat-ai/small-webrtc-transport@1.9.0(@pipecat-ai/client-js@1.13.0)':
     dependencies:
       '@daily-co/daily-js': 0.86.0
-      '@pipecat-ai/client-js': 1.8.0
+      '@pipecat-ai/client-js': 1.13.0
       dequal: 2.0.3
       lodash: 4.18.1
 
-  '@pipecat-ai/websocket-transport@1.6.2(@pipecat-ai/client-js@1.8.0)':
+  '@pipecat-ai/websocket-transport@1.6.2(@pipecat-ai/client-js@1.13.0)':
     dependencies:
       '@daily-co/daily-js': 0.89.1
-      '@pipecat-ai/client-js': 1.8.0
+      '@pipecat-ai/client-js': 1.13.0
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
       x-law: 0.3.1
@@ -7605,6 +7618,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.11
       '@types/react-dom': 19.1.8(@types/react@19.1.11)
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.16)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.16)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.16)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.1.16
+      '@types/react-dom': 19.1.9(@types/react@19.1.16)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.11)(react@19.2.1)':
     dependencies:
@@ -9917,8 +9952,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.34.0(jiti@2.6.1))
@@ -9937,8 +9972,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -9961,7 +9996,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9972,11 +10007,11 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9987,33 +10022,33 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10024,7 +10059,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10042,7 +10077,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10053,7 +10088,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13185,9 +13220,20 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@11.1.1: {}
+
   uuid@14.0.0: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Adds DTMF (touch-tone) keypad support to the kit and the Console template.

- **New `DTMFKeypad` element** (`package/src/components/elements/DTMFKeypad.tsx`): a headless `DTMFKeypadComponent` plus a connected `DTMFKeypad` that sends tones via client-react's `useDTMF()` and stays disabled until the transport is connected. Two modes via a `mode` prop: `"immediate"` (default; each press sends its tone) and `"buffered"` (digits accumulate in an editable input with backspace + Send, dispatched as one `sendDTMF` sequence). Controlled/uncontrolled buffer via `value`/`defaultValue`/`onValueChange`; sends are wrapped in try/catch and surfaced through `onToneSent`/`onError`.
- **Console template**: the keypad lives behind a phone icon in the header control cluster — a Popover on desktop (sm+) and a bottom Drawer on mobile. Gated by a `noDTMF` prop; mode selectable via `keypadMode` (default `"immediate"`).
- **New `Drawer` UI primitive** (vaul) that portals into the scoped Pipecat UI container, mirroring the existing Popover pattern.
- Re-exports `useDTMF` from the kit hooks; exports `DTMFKeypad` from elements and `Drawer*` from ui. Stories cover immediate + buffered, pure + connected.

## Dependency changes

- Peer/dev floors bumped to `@pipecat-ai/client-js >=1.13.0` (sendDTMF/DTMFButton) and `@pipecat-ai/client-react >=1.8.0` (useDTMF), across root, `package/`, and `examples/01-console`. Verified empirically these are the exact minimums where those APIs first appear.
- Added `vaul ^1.1.2` to `package` deps for the Drawer (consistent with how the other Radix primitives are declared).

## Review fixes (this branch)

- `fix(dtmf)`: `buttonProps` was spread after the internal `onClick`/`disabled`, so a consumer's `buttonProps` could silently clobber the press handler or defeat the connected-state gate — now composed. Enter in buffered mode calls `preventDefault` so embedding in a `<form>` doesn't double-trigger a native submit.
- `fix(stories)`: the client-react `>=1.8.0` bump pulls in its broken published types (a duplicated, non-assignable `PipecatClient`), which regressed `tsc` on the new DTMF story and four pre-existing stories. Applied the same `as unknown as` cast already used in `PipecatAppBase`/`SessionInfo` to those call sites.

## Known workarounds (intentional — do not "clean up")

client-react@1.8.0 ships a duplicated `PipecatClient` class in its bundled `.d.ts` instead of re-exporting client-js's, so a client-js `PipecatClient` isn't assignable to `PipecatClientProvider`'s `client` prop. Two casts are intentional until a fixed client-react ships:
- `PipecatAppBase.tsx` — `as unknown as` cast at the provider boundary.
- `SessionInfo.tsx` — a now-unnecessary `@ts-expect-error` replaced with an explicit typed cast.
- (plus the five story casts added in this branch)

There is an upstream fix in `pipecat-ai/pipecat-client-web` (branch `fix/client-react-external-client-js-types`) that removes the path alias causing Parcel to inline client-js types. Once a client-react release with that fix ships, all of the above casts can be reverted and the client-react floor bumped.

## Follow-up (not blocking)

`Console/KeypadToggle` mounts an independent desktop Popover and mobile Drawer, toggled by the `sm:` breakpoint via CSS. If the viewport crosses the breakpoint while the keypad is open, the two overlays' open-state (and, in buffered mode, their separate buffers) aren't synchronized. Edge case (the Console default is `immediate`); a focused follow-up should render a single instance chosen by a media query.

## Test plan

- [x] `pnpm --filter=@pipecat-ai/voice-ui-kit build` (tsup: JS + DTS) passes
- [x] `pnpm --filter=@pipecat-ai/voice-ui-kit lint` passes
- [x] `pnpm --filter=@pipecat-ai/voice-ui-kit test` passes (7/7)
- [x] `pnpm install --frozen-lockfile` passes (pinned pnpm@10.14.0)
- [x] `tsc --noEmit` reports no DTMF/client-react errors (only pre-existing, unrelated errors remain)
- [ ] Manual: exercise the DTMF keypad stories (immediate + buffered, pure + connected) in Ladle
