### PR TITLE
fix(ci): register new docs pages in the folder nav

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -220,8 +220,22 @@ jobs:
                primitives, templates, visualizers). Follow the structure of
                existing pages: frontmatter (title, description, source,
                changelog), prose, `<TypeTable>` for props, `<LiveComponent>`
-               examples where it makes sense.
-            5. **Do not delete pages** for removed exports. Instead, add a
+               examples where it makes sense. Creating the file is not enough
+               on its own: register it in the folder's nav per step 5.
+            5. **Register every page in its folder's `meta.json`.** Folders
+               that have a `meta.json` list their pages in a `pages` array,
+               and a page missing from that array still builds but never
+               appears in the sidebar, so readers cannot reach it. Treat this
+               as an invariant to enforce, not just a step to perform on pages
+               you created: every entry in `pages` has a matching `.mdx` in
+               that folder, and every `.mdx` in that folder is listed in
+               `pages`. Check it for pages you did not create in this run too,
+               since the docs branch persists between runs and a page added by
+               an earlier run may still be missing its entry. Use the filename
+               without the `.mdx` extension, and insert it where the array's
+               existing order implies rather than appending it (`overview`
+               stays first where present).
+            6. **Do not delete pages** for removed exports. Instead, add a
                changelog entry noting the removal and add a banner at the top
                of the page explaining the removal. Flag these in your summary.
 


### PR DESCRIPTION
## Summary

The docs generator creates a page for each newly exported public API but was never told to register it in the folder's `meta.json`. A page missing from the `pages` array still builds, so nothing fails loudly: the page just never appears in the sidebar and is unreachable.

`DTMFKeypad` is the first case to surface this (#153 adds `components/DTMFKeypad.mdx` but no nav entry), but it would recur for every new component.

Fixing it in the generator rather than hand-editing #153, since that branch is regenerated on every release-please update and manual edits there are overwritten.

## Why this is its own step, not a clause under "create new pages"

The docs branch **persists between runs**. `DTMFKeypad.mdx` already exists on it (created by an earlier run), so a rule that only fires while *creating* a page would never repair an entry that is already missing. Registration is therefore a standalone step phrased as an invariant to enforce across the folder:

> every entry in `pages` has a matching `.mdx` in that folder, and every `.mdx` in that folder is listed in `pages`

## Notes

- Prompt-only change to the `docs-update` job. No workflow logic, triggers, or permissions touched.
- `meta.json` was already within the job's allowed edit scope (`docs/content/docs/`) and its `git add docs/content/docs` already stages it, so nothing else was needed to let it write the file.
- Steps renumbered 4→6; "Do not delete pages" is now step 6.

## Test plan

- [x] Workflow YAML parses; all three jobs (`release-please`, `docs-update`, `publish`) intact
- [x] Steps numbered 1-6 with no duplicates or gaps
- [x] Nav step verified present in the `docs-update` prompt and unconditional (explicitly covers pages not created in the current run)
- [x] Confirmed the invariant holds on main today: every `meta.json` `pages` entry has a matching `.mdx`; `DTMFKeypad` is the only page missing a nav entry
- [ ] After merge: a push to main re-triggers Release Please; confirm the regenerated #153 adds `DTMFKeypad` to `docs/content/docs/components/meta.json`