### PR TITLE
docs(dtmf): refer to sendTone, not sendDTMF

### DIFF
--- a/package/src/components/elements/DTMFKeypad.stories.tsx
+++ b/package/src/components/elements/DTMFKeypad.stories.tsx
@@ -136,7 +136,7 @@ Buffered.storyName = "Buffered (Pure)";
 /**
  * Connected keypad. Requires a live Pipecat client; the keypad is disabled
  * until the transport is connected. In buffered mode (default) the sequence is
- * sent on submit; in immediate mode each press sends its tone via `sendDTMF`.
+ * sent on submit; in immediate mode each press sends its tone via `sendTone`.
  */
 export const Connected: Story<{
   mode: "immediate" | "buffered";

--- a/package/src/components/elements/DTMFKeypad.tsx
+++ b/package/src/components/elements/DTMFKeypad.tsx
@@ -70,7 +70,7 @@ const TONE_RAMP = 0.01;
  * Returns a function that plays a key's DTMF tone locally as press feedback.
  *
  * This is a cosmetic sidetone only: the actual signalling happens over the
- * transport via `sendDTMF`. The tone is synthesized from the two frequencies
+ * transport via `sendTone`. The tone is synthesized from the two frequencies
  * that define the key rather than played from a bundled audio file.
  */
 const useDTMFTone = (enabled: boolean, volume: number) => {
@@ -397,7 +397,7 @@ export interface DTMFKeypadProps extends DTMFKeypadBaseProps {
   /** Called after tone(s) are successfully sent. */
   onToneSent?: (sequence: string) => void;
   /**
-   * Called if sending fails. `sendDTMF` throws when the transport isn't ready
+   * Called if sending fails. `sendTone` throws when the transport isn't ready
    * or the connected bot doesn't support DTMF (RTVI protocol < 2.0.0); the
    * error is caught and forwarded here instead of surfacing uncaught.
    */
@@ -407,7 +407,7 @@ export interface DTMFKeypadProps extends DTMFKeypadBaseProps {
 /**
  * Connected DTMFKeypad that integrates with the Pipecat Client SDK.
  *
- * In `"buffered"` mode (default) the entered sequence is sent as one `sendDTMF`
+ * In `"buffered"` mode (default) the entered sequence is sent as one `sendTone`
  * call on submit, so a mistyped digit can be corrected before anything is
  * transmitted; in `"immediate"` mode each key press sends that tone right away,
  * which suits navigating a live IVR menu. The keypad is disabled until the


### PR DESCRIPTION
## Summary

The `DTMFKeypad` JSDoc named `sendDTMF` in four places. That is the underlying client-js method; what the component actually calls, and what a consumer sees, is the `sendTone` function returned by `useDTMF`.

Review on #153 flagged this on the generated docs page. The cause is here rather than there: the docs generator copies these JSDoc strings verbatim into the published prop tables, so the wrong name propagated into the v0.12.0 docs.

Fixed at the source rather than on the generated page, because step 1 of the generator prompt is "Update prose & prop tables so they match the current API". A page-only fix would be re-synced back to `sendDTMF` on the next regeneration. With the source corrected, the next run should produce the right name on its own.

## Changes

| Location | Before | After |
| --- | --- | --- |
| `DTMFKeypad.tsx` `onError` doc | "`sendDTMF` throws when the transport isn't ready" | `sendTone` |
| `DTMFKeypad.tsx` component doc | "sent as one `sendDTMF` call" | `sendTone` |
| `DTMFKeypad.tsx` sidetone comment | "signalling happens over the transport via `sendDTMF`" | `sendTone` |
| `DTMFKeypad.stories.tsx` story doc | "sends its tone via `sendDTMF`" | `sendTone` |

Comment-only. No behavior change.

## Test plan

- [x] `grep -rn "sendDTMF" package/src/` returns nothing; source is consistent on `sendTone`
- [x] Lint, build, and tests pass
- [x] Corrected wording confirmed present in the built `dist/index.d.ts`
- [ ] After merge: confirm the regenerated #153 prop table reads `sendTone`