### PR TITLE
Add livekit transport support

### DIFF
--- a/docs/content/docs/components/PipecatAppBase.mdx
+++ b/docs/content/docs/components/PipecatAppBase.mdx
@@ -447,8 +447,8 @@ export default function Home() {
     },
     transportOptions: {
       description:
-        "Optional configuration options for the transport (SmallWebRTC, Daily, WebSocket, or MoQ specific)",
-      type: "SmallWebRTCTransportConstructorOptions | DailyTransportConstructorOptions | WebSocketTransportConstructorOptions | MoqTransportOptions",
+        "Optional configuration options for the transport (SmallWebRTC, Daily, WebSocket, LiveKit, or MoQ specific)",
+      type: "SmallWebRTCTransportConstructorOptions | DailyTransportConstructorOptions | WebSocketTransportConstructorOptions | LiveKitTransportConstructorOptions |MoqTransportOptions",
       required: false,
     },
     clientOptions: {

--- a/docs/content/docs/components/PipecatAppBase.mdx
+++ b/docs/content/docs/components/PipecatAppBase.mdx
@@ -267,7 +267,59 @@ export default function Home() {
 
 Transport-specific construction options can be passed via `transportOptions`, which is typed as `WebSocketTransportConstructorOptions` when `transportType="websocket"`. See the [@pipecat-ai/websocket-transport](https://www.npmjs.com/package/@pipecat-ai/websocket-transport) package for the full option list.
 
-### 8. Using MoQ Transport
+### 8. Using LiveKit Transport
+
+The `livekit` transport connects to a Pipecat bot through [LiveKit](https://livekit.io)'s WebRTC infrastructure. Like the WebSocket and MoQ transports, it's provided by an optional peer package.
+
+<Callout type="warning">
+  The LiveKit transport package is a peer dependency. Install it before
+  setting `transportType="livekit"`, otherwise the transport will fail to load
+  at runtime.
+</Callout>
+
+```bash
+npm install @pipecat-ai/livekit-transport
+```
+
+Point the component at a `startBot` endpoint that returns a LiveKit room URL and access token:
+
+```tsx
+import { PipecatAppBase } from "@pipecat-ai/voice-ui-kit";
+
+export default function Home() {
+  return (
+    <PipecatAppBase
+      transportType="livekit"
+      startBotParams={{
+        endpoint: "/api/start",
+        requestData: {
+          transport: "livekit",
+        },
+      }}
+    >
+      <YourCustomComponent />
+    </PipecatAppBase>
+  );
+}
+```
+
+Alternatively, if you already have a room URL and token (for example from your own auth flow), pass them via `connectParams`:
+
+```tsx
+<PipecatAppBase
+  transportType="livekit"
+  connectParams={{
+    url: "wss://your-livekit-server.com",
+    token: "your-livekit-access-token",
+  }}
+>
+  <YourCustomComponent />
+</PipecatAppBase>
+```
+
+Transport-specific construction options can be passed via `transportOptions`, which is typed as `LiveKitTransportConstructorOptions` (LiveKit's [`RoomOptions`](https://docs.livekit.io/reference/client-sdk-js/interfaces/RoomOptions.html)) when `transportType="livekit"`. See the [@pipecat-ai/livekit-transport](https://www.npmjs.com/package/@pipecat-ai/livekit-transport) package for details, including [`RoomConnectOptions`](https://docs.livekit.io/reference/client-sdk-js/interfaces/RoomConnectOptions.html) accepted via `roomConnectionOptions` on `connectParams`.
+
+### 9. Using MoQ Transport
 
 The `moq` transport speaks [Media-over-QUIC](https://datatracker.ietf.org/group/moq/about/) to a Pipecat bot via a moq-lite relay, using WebTransport (with a WebSocket fallback). Like the WebSocket transport, it's provided by an optional peer package.
 
@@ -339,7 +391,7 @@ For local development against a self-signed relay, pin the certificate via `serv
 
 `MoqTransportOptions` also accepts `namespace`, `clientId`, `botId`, `transcriptTrack`, and `audioLatencyMs` for tuning the broadcast paths and jitter buffer. See the [@pipecat-ai/moq-transport](https://www.npmjs.com/package/@pipecat-ai/moq-transport) package for the full option list.
 
-### 9. Using onClient Callback
+### 10. Using onClient Callback
 
 `onClient` fires once per client instance, the moment the client is created and before any connect attempt. It's the right place to attach `client.on(...)` listeners or to run setup that needs the client handle from outside the provider tree (e.g. when consuming `ConsoleTemplate`, where there is no render-prop slot to call `usePipecatClient()` from).
 
@@ -396,7 +448,7 @@ const handleClient = (client: PipecatClient) => {
 };
 ```
 
-### 10. Using startBotParams
+### 11. Using startBotParams
 
 You can use `startBotParams` instead of `connectParams` to start a bot session:
 
@@ -441,14 +493,14 @@ export default function Home() {
     },
     transportType: {
       description:
-        "The type of transport to use for the connection (smallwebrtc, daily, websocket, or moq)",
-      type: '"smallwebrtc" | "daily" | "websocket" | "moq"',
+        "The type of transport to use for the connection (smallwebrtc, daily, websocket, livekit, or moq)",
+      type: '"smallwebrtc" | "daily" | "websocket" | "livekit" | "moq"',
       required: true,
     },
     transportOptions: {
       description:
         "Optional configuration options for the transport (SmallWebRTC, Daily, WebSocket, LiveKit, or MoQ specific)",
-      type: "SmallWebRTCTransportConstructorOptions | DailyTransportConstructorOptions | WebSocketTransportConstructorOptions | LiveKitTransportConstructorOptions |MoqTransportOptions",
+      type: "SmallWebRTCTransportConstructorOptions | DailyTransportConstructorOptions | WebSocketTransportConstructorOptions | LiveKitTransportConstructorOptions | MoqTransportOptions",
       required: false,
     },
     clientOptions: {

--- a/docs/content/docs/components/SessionInfo.mdx
+++ b/docs/content/docs/components/SessionInfo.mdx
@@ -100,6 +100,8 @@ The component automatically detects and displays:
 
 - **Daily**: Shows "Daily (v[version])" when using Daily transport, where [version] is the Daily.js version number
 - **Small WebRTC**: Shows "Small WebRTC" when using Small WebRTC transport
+- **LiveKit**: Shows "LiveKit" when using LiveKit transport
+- **MoQ**: Shows "MoQ" when using MoQ transport
 - **Unknown**: Shows "Unknown" if transport type cannot be determined
 
 ## Copy Functionality

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -59,6 +59,8 @@ npm install @pipecat-ai/daily-transport
 # or
 npm install @pipecat-ai/websocket-transport
 # or
+npm install @pipecat-ai/livekit-transport
+# or
 npm install @pipecat-ai/moq-transport
 ```
 
@@ -68,6 +70,8 @@ pnpm add @pipecat-ai/small-webrtc-transport
 pnpm add @pipecat-ai/daily-transport
 # or
 pnpm add @pipecat-ai/websocket-transport
+# or
+pnpm add @pipecat-ai/livekit-transport
 # or
 pnpm add @pipecat-ai/moq-transport
 ```
@@ -79,6 +83,8 @@ yarn add @pipecat-ai/daily-transport
 # or
 yarn add @pipecat-ai/websocket-transport
 # or
+yarn add @pipecat-ai/livekit-transport
+# or
 yarn add @pipecat-ai/moq-transport
 ```
 
@@ -88,6 +94,8 @@ bun add @pipecat-ai/small-webrtc-transport
 bun add @pipecat-ai/daily-transport
 # or
 bun add @pipecat-ai/websocket-transport
+# or
+bun add @pipecat-ai/livekit-transport
 # or
 bun add @pipecat-ai/moq-transport
 ```

--- a/docs/content/docs/templates/console.mdx
+++ b/docs/content/docs/templates/console.mdx
@@ -148,6 +148,46 @@ export default function App() {
 }
 ```
 
+### With LiveKit Transport
+
+The `livekit` transport requires installing the optional peer package:
+
+```bash
+npm install @pipecat-ai/livekit-transport
+```
+
+```tsx
+import { ConsoleTemplate } from "@pipecat-ai/voice-ui-kit";
+
+export default function App() {
+  return (
+    <div className="h-screen">
+      <ConsoleTemplate
+        transportType="livekit"
+        startBotParams={{
+          endpoint: "/api/start",
+          requestData: {
+            transport: "livekit",
+          },
+        }}
+      />
+    </div>
+  );
+}
+```
+
+Alternatively, if you already have a room URL and token, pass them via `connectParams`:
+
+```tsx
+<ConsoleTemplate
+  transportType="livekit"
+  connectParams={{
+    url: "wss://your-livekit-server.com",
+    token: "your-livekit-access-token",
+  }}
+/>
+```
+
 ### With MoQ Transport
 
 The `moq` (Media-over-QUIC) transport requires installing the optional peer package:

--- a/examples/01-console/README.md
+++ b/examples/01-console/README.md
@@ -9,6 +9,13 @@ A minimal example showing how to use the `ConsoleTemplate` component with Next.j
 - No user video (audio-only)
 - Built-in theme support
 
+## Prerequisites
+
+This example is a client only — connecting requires a Pipecat bot server
+running separately (not part of this repo) that can start a bot and return
+transport connection details. By default the app expects it at
+`http://localhost:7860`; see `env.example` for how to point it elsewhere.
+
 ## Quick Start
 
 ```bash
@@ -28,7 +35,8 @@ cp env.example .env
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to view the example.
+Open [http://localhost:3000](http://localhost:3000) to view the example. Make
+sure your bot server is running first, or connecting will fail.
 
 ## What's Included
 

--- a/examples/01-console/env.example
+++ b/examples/01-console/env.example
@@ -1,4 +1,26 @@
+# Client-side base path the transport picker uses to reach the bot-start
+# endpoint (it appends "/start"). Two setups, pick one:
+#
+# 1) Local bot server (default): leave this empty. next.config.ts rewrites
+#    /start straight to http://0.0.0.0:7860/start, so BOT_START_URL and
+#    BOT_START_PUBLIC_API_KEY below are unused.
 NEXT_PUBLIC_BOT_HOST=""
+#
+# 2) Hosted/authenticated bot-start service: set this to "/api" instead, so
+#    requests go through src/app/api/start/route.ts, which proxies
+#    server-side to BOT_START_URL and attaches BOT_START_PUBLIC_API_KEY as a
+#    Bearer token (keeping the key out of the browser).
+# NEXT_PUBLIC_BOT_HOST="/api"
 
+# Only used when NEXT_PUBLIC_BOT_HOST="/api" above. One URL handles every
+# transport in this example - the transport picker just changes the
+# "transport" field in the request body:
+#   SmallWebRTC -> "webrtc"
+#   Daily       -> "daily"
+#   WebSocket   -> "websocket"
+#   LiveKit     -> "livekit"
+#   MoQ         -> "moq"
 BOT_START_URL="http://localhost:7860/api/offer"
+
+# Bearer token sent to BOT_START_URL. Only used when NEXT_PUBLIC_BOT_HOST="/api".
 BOT_START_PUBLIC_API_KEY="pk_"

--- a/examples/01-console/package.json
+++ b/examples/01-console/package.json
@@ -16,6 +16,7 @@
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/voice-ui-kit": "workspace:*",
     "@pipecat-ai/websocket-transport": ">=1.6.2",
+    "@pipecat-ai/livekit-transport": "^1.0.0",
     "@pipecat-ai/moq-transport": "^0.1.0",
     "next": "15.5.23",
     "uuid": "^14.0.0",

--- a/examples/01-console/src/app/api/start/route.ts
+++ b/examples/01-console/src/app/api/start/route.ts
@@ -23,11 +23,12 @@ export async function POST(request: NextRequest) {
     // Get the JSON response
     const data = await response.json();
 
-    // Return the complete JSON response
-    return NextResponse.json({
-        room_url: data.dailyRoom,
-        token: data.dailyToken,
-    });
+    // Return the complete JSON response as-is; each transport's
+    // connection params have a different shape (e.g. Daily uses
+    // room_url/token, WebSocket uses wsUrl, LiveKit uses url/token),
+    // and the bot server already returns the shape matching the
+    // requested transport.
+    return NextResponse.json(data);
   } catch (error) {
     console.error('Error in offer API route:', error);
     return NextResponse.json(

--- a/examples/01-console/src/app/page.tsx
+++ b/examples/01-console/src/app/page.tsx
@@ -7,12 +7,18 @@ import {
 } from "@pipecat-ai/voice-ui-kit";
 import React, { useState } from "react";
 
-type TransportType = "smallwebrtc" | "daily" | "websocket" | "moq";
+type TransportType =
+  | "smallwebrtc"
+  | "daily"
+  | "websocket"
+  | "livekit"
+  | "moq";
 
 const TRANSPORT_OPTIONS: { value: TransportType; label: string }[] = [
   { value: "smallwebrtc", label: "SmallWebRTC" },
   { value: "daily", label: "Daily" },
   { value: "websocket", label: "WebSocket" },
+  { value: "livekit", label: "LiveKit" },
   { value: "moq", label: "MoQ" },
 ];
 
@@ -56,6 +62,15 @@ function getTransportProps(
           endpoint: `${botHost}/start`,
           requestData: {
             transport: "websocket",
+          },
+        },
+      };
+    case "livekit":
+      return {
+        startBotParams: {
+          endpoint: `${botHost}/start`,
+          requestData: {
+            transport: "livekit",
           },
         },
       };

--- a/examples/01-console/tsconfig.json
+++ b/examples/01-console/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {

--- a/package/package.json
+++ b/package/package.json
@@ -49,6 +49,7 @@
     "@pipecat-ai/client-js": ">=1.13.0",
     "@pipecat-ai/client-react": ">=1.8.0",
     "@pipecat-ai/daily-transport": ">=1.6.0",
+    "@pipecat-ai/livekit-transport": ">=1.0.0",
     "@pipecat-ai/moq-transport": "^0.1.0",
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/websocket-transport": ">=1.6.2",
@@ -72,6 +73,10 @@
     "@pipecat-ai/daily-transport": {
       "optional": true,
       "version": "^1.6.0"
+    },
+    "@pipecat-ai/livekit-transport": {
+      "optional": true,
+      "version": "^1.0.0"
     },
     "@pipecat-ai/moq-transport": {
       "optional": true,
@@ -126,12 +131,13 @@
     "@daily-co/daily-js": "^0.85.0",
     "@eslint/js": "^9.36.0",
     "@ladle/react": "^5.0.3",
-    "@pipecat-ai/client-js": "^1.13.0",
-    "@pipecat-ai/client-react": "^1.8.0",
-    "@pipecat-ai/daily-transport": "^1.6.0",
-    "@pipecat-ai/moq-transport": "^0.1.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.9.0",
-    "@pipecat-ai/websocket-transport": "^1.6.2",
+    "@pipecat-ai/client-js": "link:../../client/client-js",
+    "@pipecat-ai/client-react": "link:../../client/client-react",
+    "@pipecat-ai/daily-transport": "link:../../transports/transports/daily",
+    "@pipecat-ai/livekit-transport": "link:../../transports/transports/livekit-transport",
+    "@pipecat-ai/moq-transport": "link:../../transports/transports/moq-transport",
+    "@pipecat-ai/small-webrtc-transport": "link:../../transports/transports/small-webrtc-transport",
+    "@pipecat-ai/websocket-transport": "link:../../transports/transports/websocket-transport",
     "@tailwindcss/vite": "^4.1.13",
     "@types/node": "^22.18.8",
     "@types/react": "^19.1.16",

--- a/package/package.json
+++ b/package/package.json
@@ -49,6 +49,7 @@
     "@pipecat-ai/client-js": ">=1.13.0",
     "@pipecat-ai/client-react": ">=1.8.0",
     "@pipecat-ai/daily-transport": ">=1.6.0",
+    "@pipecat-ai/livekit-transport": "^1.0.0",
     "@pipecat-ai/moq-transport": "^0.1.0",
     "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
     "@pipecat-ai/websocket-transport": ">=1.6.2",
@@ -72,6 +73,10 @@
     "@pipecat-ai/daily-transport": {
       "optional": true,
       "version": "^1.6.0"
+    },
+    "@pipecat-ai/livekit-transport": {
+      "optional": true,
+      "version": "^1.0.0"
     },
     "@pipecat-ai/moq-transport": {
       "optional": true,
@@ -129,6 +134,7 @@
     "@pipecat-ai/client-js": "^1.13.0",
     "@pipecat-ai/client-react": "^1.8.0",
     "@pipecat-ai/daily-transport": "^1.6.0",
+    "@pipecat-ai/livekit-transport": "^1.0.0",
     "@pipecat-ai/moq-transport": "^0.1.0",
     "@pipecat-ai/small-webrtc-transport": "^1.9.0",
     "@pipecat-ai/websocket-transport": "^1.6.2",

--- a/package/src/components/PipecatAppBase.tsx
+++ b/package/src/components/PipecatAppBase.tsx
@@ -14,6 +14,7 @@ import {
 } from "@pipecat-ai/client-js";
 import { PipecatClientProvider } from "@pipecat-ai/client-react";
 import type { DailyTransportConstructorOptions } from "@pipecat-ai/daily-transport";
+import type { LiveKitTransportConstructorOptions } from "@pipecat-ai/livekit-transport";
 import type {
   SmallWebRTCTransport,
   SmallWebRTCTransportConstructorOptions,
@@ -35,12 +36,13 @@ export interface PipecatBaseProps {
     response: TransportConnectionParams,
   ) => TransportConnectionParams | Promise<TransportConnectionParams>;
   /** Type of transport to use for the connection */
-  transportType: "smallwebrtc" | "daily" | "websocket" | "moq";
+  transportType: "smallwebrtc" | "daily" | "websocket" | "livekit" | "moq";
   /** Options for configuring the transport. */
   transportOptions?:
     | SmallWebRTCTransportConstructorOptions
     | DailyTransportConstructorOptions
     | WebSocketTransportConstructorOptions
+    | LiveKitTransportConstructorOptions
     | MoqTransportOptions;
   /** Optional configuration options for the Pipecat client */
   clientOptions?: Partial<PipecatClientOptions>;
@@ -66,7 +68,8 @@ export interface PipecatBaseProps {
    * @returns React.ReactNode
    */
   children:
-    ((props: PipecatBaseChildProps) => React.ReactNode) | React.ReactNode;
+    | ((props: PipecatBaseChildProps) => React.ReactNode)
+    | React.ReactNode;
 }
 
 /**

--- a/package/src/components/elements/SessionInfo.tsx
+++ b/package/src/components/elements/SessionInfo.tsx
@@ -47,6 +47,8 @@ export const SessionInfo: React.FC<Props> = ({
     transportTypeName = `Daily (v${Daily.version()})`;
   } else if (transportServiceName === "small-webrtc-transport") {
     transportTypeName = "Small WebRTC";
+  } else if (transportServiceName === "livekit-transport") {
+    transportTypeName = "LiveKit";
   } else if (transportServiceName === "moq-transport") {
     transportTypeName = "MoQ";
   }

--- a/package/src/lib/transports.ts
+++ b/package/src/lib/transports.ts
@@ -1,6 +1,11 @@
 import type { Transport } from "@pipecat-ai/client-js";
 
-export type TransportType = "daily" | "smallwebrtc" | "websocket" | "moq";
+export type TransportType =
+  | "daily"
+  | "smallwebrtc"
+  | "websocket"
+  | "livekit"
+  | "moq";
 
 // Use the actual types from the packages without importing them at build time
 export type DailyTransportOptions = ConstructorParameters<
@@ -12,6 +17,9 @@ export type SmallWebRTCTransportOptions = ConstructorParameters<
 export type WebSocketTransportOptions = ConstructorParameters<
   typeof import("@pipecat-ai/websocket-transport").WebSocketTransport
 >[0];
+export type LiveKitTransportOptions = ConstructorParameters<
+  typeof import("@pipecat-ai/livekit-transport").LiveKitTransport
+>[0];
 export type MoqTransportOptions = ConstructorParameters<
   typeof import("@pipecat-ai/moq-transport").MoqTransport
 >[0];
@@ -20,6 +28,7 @@ export interface TransportModule {
   DailyTransport: typeof import("@pipecat-ai/daily-transport").DailyTransport;
   SmallWebRTCTransport: typeof import("@pipecat-ai/small-webrtc-transport").SmallWebRTCTransport;
   WebSocketTransport: typeof import("@pipecat-ai/websocket-transport").WebSocketTransport;
+  LiveKitTransport: typeof import("@pipecat-ai/livekit-transport").LiveKitTransport;
   MoqTransport: typeof import("@pipecat-ai/moq-transport").MoqTransport;
 }
 
@@ -46,6 +55,12 @@ export async function loadTransport(transportType: TransportType) {
         );
         return { WebSocketTransport };
       }
+      case "livekit": {
+        const { LiveKitTransport } = await import(
+          "@pipecat-ai/livekit-transport"
+        );
+        return { LiveKitTransport };
+      }
       case "moq": {
         const { MoqTransport } = await import("@pipecat-ai/moq-transport");
         return { MoqTransport };
@@ -63,7 +78,9 @@ export async function loadTransport(transportType: TransportType) {
           ? "npm install @pipecat-ai/small-webrtc-transport"
           : transportType === "websocket"
             ? "npm install @pipecat-ai/websocket-transport"
-            : "npm install @pipecat-ai/moq-transport";
+            : transportType === "livekit"
+              ? "npm install @pipecat-ai/livekit-transport"
+              : "npm install @pipecat-ai/moq-transport";
     throw new Error(
       `Failed to load transport "${transportType}". Make sure the package is installed: ${installHint}. Original error: ${errorMessage}`,
     );
@@ -73,7 +90,7 @@ export async function loadTransport(transportType: TransportType) {
 /**
  * Creates a transport instance based on the transport type.
  *
- * @param transportType - The type of transport to create ("daily", "smallwebrtc", "websocket", or "moq")
+ * @param transportType - The type of transport to create ("daily", "smallwebrtc", "websocket", "livekit",or "moq")
  * @param options - Transport-specific options
  *
  */
@@ -90,6 +107,10 @@ export async function createTransport(
   options?: WebSocketTransportOptions,
 ): Promise<Transport>;
 export async function createTransport(
+  transportType: "livekit",
+  options?: LiveKitTransportOptions,
+): Promise<Transport>;
+export async function createTransport(
   transportType: "moq",
   options?: MoqTransportOptions,
 ): Promise<Transport>;
@@ -99,6 +120,7 @@ export async function createTransport(
     | DailyTransportOptions
     | SmallWebRTCTransportOptions
     | WebSocketTransportOptions
+    | LiveKitTransportOptions
     | MoqTransportOptions,
 ): Promise<Transport>;
 export async function createTransport(
@@ -107,6 +129,7 @@ export async function createTransport(
     | DailyTransportOptions
     | SmallWebRTCTransportOptions
     | WebSocketTransportOptions
+    | LiveKitTransportOptions
     | MoqTransportOptions,
 ): Promise<Transport> {
   const transportModule = await loadTransport(transportType);
@@ -132,6 +155,13 @@ export async function createTransport(
         throw new Error("WebSocketTransport not found in loaded module");
       }
       return new WebSocketTransport(options as WebSocketTransportOptions);
+    }
+    case "livekit": {
+      const { LiveKitTransport } = transportModule;
+      if (!LiveKitTransport) {
+        throw new Error("LiveKitTransport not found in loaded module");
+      }
+      return new LiveKitTransport(options as LiveKitTransportOptions);
     }
     case "moq": {
       const { MoqTransport } = transportModule;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,23 +510,26 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(@types/node@22.18.8)(@types/react@19.1.16)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tsx@4.20.5)(typescript@5.8.3)(yaml@2.8.3)
       '@pipecat-ai/client-js':
-        specifier: ^1.13.0
-        version: 1.13.0
+        specifier: link:../../client/client-js
+        version: link:../../client/client-js
       '@pipecat-ai/client-react':
-        specifier: ^1.8.0
-        version: 1.8.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@pipecat-ai/client-js@1.13.0)(@types/react@19.1.16)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: link:../../client/client-react
+        version: link:../../client/client-react
       '@pipecat-ai/daily-transport':
-        specifier: ^1.6.0
-        version: 1.6.0(@pipecat-ai/client-js@1.13.0)
+        specifier: link:../../transports/transports/daily
+        version: link:../../transports/transports/daily
+      '@pipecat-ai/livekit-transport':
+        specifier: link:../../transports/transports/livekit-transport
+        version: link:../../transports/transports/livekit-transport
       '@pipecat-ai/moq-transport':
-        specifier: ^0.1.0
-        version: 0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
+        specifier: link:../../transports/transports/moq-transport
+        version: link:../../transports/transports/moq-transport
       '@pipecat-ai/small-webrtc-transport':
-        specifier: ^1.9.0
-        version: 1.9.0(@pipecat-ai/client-js@1.13.0)
+        specifier: link:../../transports/transports/small-webrtc-transport
+        version: link:../../transports/transports/small-webrtc-transport
       '@pipecat-ai/websocket-transport':
-        specifier: ^1.6.2
-        version: 1.6.2(@pipecat-ai/client-js@1.13.0)
+        specifier: link:../../transports/transports/websocket-transport
+        version: link:../../transports/transports/websocket-transport
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.1.13(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.5)(yaml@2.8.3))
@@ -1173,105 +1176,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1503,28 +1490,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.18':
     resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.18':
     resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.18':
     resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.18':
     resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
@@ -2097,42 +2080,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.2':
     resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.2':
     resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.2':
     resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.2':
     resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.2':
     resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.2':
     resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
@@ -2197,79 +2174,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2401,28 +2365,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.5':
     resolution: {integrity: sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.5':
     resolution: {integrity: sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.5':
     resolution: {integrity: sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.5':
     resolution: {integrity: sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==}
@@ -2531,56 +2491,48 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.13':
     resolution: {integrity: sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -2928,49 +2880,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4678,56 +4622,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -7511,38 +7447,11 @@ snapshots:
       - react
       - solid-js
 
-  '@moq/hang@0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)':
-    dependencies:
-      '@kixelated/libavjs-webcodecs-polyfill': 0.5.5
-      '@libav.js/variant-opus-af': 6.9.8
-      '@moq/json': 0.2.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/loc': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
-      '@svta/cml-iso-bmff': 1.0.2(@svta/cml-utils@1.5.0)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@svta/cml-utils'
-      - '@types/react'
-      - react
-      - solid-js
-
   '@moq/json@0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
     dependencies:
       '@moq/flate': 0.1.1
       '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
       '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
-      - solid-js
-
-  '@moq/json@0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/flate': 0.1.1
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@types/react'
@@ -7560,29 +7469,9 @@ snapshots:
       - react
       - solid-js
 
-  '@moq/json@0.2.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/flate': 0.1.1
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
-      - solid-js
-
   '@moq/loc@0.1.2(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
     dependencies:
       '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
-      - solid-js
-      - zod
-
-  '@moq/loc@0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -7598,30 +7487,10 @@ snapshots:
       - react
       - solid-js
 
-  '@moq/msf@0.1.4(@types/react@19.1.16)(react@19.2.1)':
-    dependencies:
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
-      - solid-js
-
   '@moq/net@0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
     dependencies:
       '@moq/qmux': 0.1.3
       '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
-      async-mutex: 0.5.0
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
-      - solid-js
-
-  '@moq/net@0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/qmux': 0.1.3
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
       async-mutex: 0.5.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -7642,19 +7511,6 @@ snapshots:
       - solid-js
       - zod
 
-  '@moq/publish@0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)
-      '@moq/json': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
-    transitivePeerDependencies:
-      - '@svta/cml-utils'
-      - '@types/react'
-      - react
-      - solid-js
-      - zod
-
   '@moq/qmux@0.1.3':
     dependencies:
       '@moq/web-socket-stream': 0.1.0
@@ -7664,11 +7520,6 @@ snapshots:
       '@types/react': 19.1.11
       react: 19.2.1
 
-  '@moq/signals@0.1.10(@types/react@19.1.16)(react@19.2.1)':
-    optionalDependencies:
-      '@types/react': 19.1.16
-      react: 19.2.1
-
   '@moq/watch@0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
     dependencies:
       '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)
@@ -7676,20 +7527,6 @@ snapshots:
       '@moq/msf': 0.1.4(@types/react@19.1.11)(react@19.2.1)
       '@moq/net': 0.1.9(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
       '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
-    transitivePeerDependencies:
-      - '@svta/cml-utils'
-      - '@types/react'
-      - react
-      - solid-js
-      - zod
-
-  '@moq/watch@0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)
-      '@moq/json': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/msf': 0.1.4(@types/react@19.1.16)(react@19.2.1)
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
     transitivePeerDependencies:
       - '@svta/cml-utils'
       - '@types/react'
@@ -7827,22 +7664,6 @@ snapshots:
       '@moq/publish': 0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
       '@moq/signals': 0.1.10(@types/react@19.1.11)(react@19.2.1)
       '@moq/watch': 0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
-      '@pipecat-ai/client-js': 1.13.0
-    transitivePeerDependencies:
-      - '@svta/cml-utils'
-      - '@types/react'
-      - react
-      - solid-js
-      - zod
-
-  '@pipecat-ai/moq-transport@0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)':
-    dependencies:
-      '@moq/hang': 0.2.16(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)
-      '@moq/json': 0.1.2(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/net': 0.1.9(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/publish': 0.2.17(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
-      '@moq/signals': 0.1.10(@types/react@19.1.16)(react@19.2.1)
-      '@moq/watch': 0.2.19(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
       '@pipecat-ai/client-js': 1.13.0
     transitivePeerDependencies:
       - '@svta/cml-utils'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       '@pipecat-ai/daily-transport':
         specifier: ^1.6.0
         version: 1.6.0(@pipecat-ai/client-js@1.13.0)
+      '@pipecat-ai/livekit-transport':
+        specifier: ^1.0.0
+        version: 1.0.0(@pipecat-ai/client-js@1.13.0)(@types/dom-mediacapture-record@1.0.22)
       '@pipecat-ai/moq-transport':
         specifier: ^0.1.0
         version: 0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.16)(react@19.2.1)(zod@4.4.3)
@@ -730,6 +733,9 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
 
   '@bufbuild/protobuf@2.12.0':
     resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
@@ -1386,6 +1392,12 @@ packages:
   '@libav.js/variant-opus-af@6.9.8':
     resolution: {integrity: sha512-4v4kBOoNnmafubEiBof+ATtr7KcU2/kL+G2hXU61orvC4Lt5OViBXnHdUHCh5ZSQQSmx9nOFEgbYGGYTrBufXQ==}
 
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.50.4':
+    resolution: {integrity: sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -1564,6 +1576,11 @@ packages:
     resolution: {integrity: sha512-QmJTgh2rncP3APLwWbM9N/WYMip0a1biTXP7IJ/WZqx0VNuN7S8wbNl7mmzNIMyxReIaG7soBwVfB0sOd389tQ==}
     peerDependencies:
       '@pipecat-ai/client-js': ~1.6.0
+
+  '@pipecat-ai/livekit-transport@1.0.0':
+    resolution: {integrity: sha512-q7KVg3b6K5OmAK7f6lu1RxKcE+DyRLpJDTt7aG499VmQ3dZzxjUAxJAtl3yssWnHwqkXPA39+2J1sqnyUAbT/w==}
+    peerDependencies:
+      '@pipecat-ai/client-js': ~1.13.0
 
   '@pipecat-ai/moq-transport@0.1.0':
     resolution: {integrity: sha512-bDuOyOx+wx/If3410VihaO+SEZ062hYBy7IjEj7APhRAmgj5qA6N5jCgF/AxyKs+70cEnhSP77pwsTMp2s/uMQ==}
@@ -2633,6 +2650,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2834,6 +2854,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2939,7 +2960,7 @@ packages:
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: '>=7.3.2 <8.0.0'
+      vite: '>=6.4.2'
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -3758,6 +3779,7 @@ packages:
   eslint@9.34.0:
     resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3768,6 +3790,7 @@ packages:
   eslint@9.36.0:
     resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4058,6 +4081,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -4458,6 +4482,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.12:
+    resolution: {integrity: sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==}
+
   jotai@2.18.1:
     resolution: {integrity: sha512-e0NOzK+yRFwHo7DOp0DS0Ycq74KMEAObDWFGmfEL28PD9nLqBTt3/Ug7jf9ca72x0gC9LQZG9zH+0ISICmy3iA==}
     engines: {node: '>=12.20.0'}
@@ -4702,6 +4729,11 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
+  livekit-client@2.22.3:
+    resolution: {integrity: sha512-jw9zBKXY5Gtr5MZ7vEON3QhMNccuDvYHck1PFSyG1aaateQPqgKZFBMgZkFZaXHIf9RV4MDW5xpTK2b/+qbwOg==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4741,6 +4773,10 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4763,6 +4799,10 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  machina@7.0.1:
+    resolution: {integrity: sha512-0Xkgs8NeBvO2hW6bjJT8ewLWrMfh1haMPstaghpASWjXkLjRhtDiaJG1Kb7mslaOHxZYxpH7PIjpmirRVYbMMA==}
+    engines: {node: '>=22.22'}
 
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
@@ -5621,6 +5661,13 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5955,6 +6002,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -6329,6 +6377,10 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webrtc-adapter@9.0.6:
+    resolution: {integrity: sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
@@ -6616,6 +6668,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bufbuild/protobuf@1.10.1': {}
 
   '@bufbuild/protobuf@2.12.0': {}
 
@@ -7367,6 +7421,12 @@ snapshots:
 
   '@libav.js/variant-opus-af@6.9.8': {}
 
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.50.4':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1':
@@ -7728,6 +7788,13 @@ snapshots:
     dependencies:
       '@daily-co/daily-js': 0.86.0
       '@pipecat-ai/client-js': 1.13.0
+
+  '@pipecat-ai/livekit-transport@1.0.0(@pipecat-ai/client-js@1.13.0)(@types/dom-mediacapture-record@1.0.22)':
+    dependencies:
+      '@pipecat-ai/client-js': 1.13.0
+      livekit-client: 2.22.3(@types/dom-mediacapture-record@1.0.22)
+    transitivePeerDependencies:
+      - '@types/dom-mediacapture-record'
 
   '@pipecat-ai/moq-transport@0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)':
     dependencies:
@@ -9038,6 +9105,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/dom-mediacapture-record@1.0.22': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -10283,7 +10352,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -10303,7 +10372,7 @@ snapshots:
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.34.0(jiti@2.6.1))
@@ -10337,7 +10406,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10352,7 +10421,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10378,7 +10447,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10407,7 +10476,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11479,6 +11548,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.12: {}
+
   jotai@2.18.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.1.11)(react@19.2.1):
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -11689,6 +11760,20 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  livekit-client@2.22.3(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.50.4
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.2.12
+      loglevel: 1.9.2
+      machina: 7.0.1
+      sdp-transform: 2.15.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.6
+
   load-tsconfig@0.2.5: {}
 
   locate-path@6.0.0:
@@ -11721,6 +11806,8 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
+  loglevel@1.9.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -11738,6 +11825,8 @@ snapshots:
       react: 19.2.1
 
   lz-string@1.5.0: {}
+
+  machina@7.0.1: {}
 
   magic-string@0.30.18:
     dependencies:
@@ -12931,6 +13020,10 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -13725,6 +13818,10 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   webidl-conversions@4.0.2: {}
+
+  webrtc-adapter@9.0.6:
+    dependencies:
+      sdp: 3.2.2
 
   whatwg-url@7.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@pipecat-ai/daily-transport':
         specifier: '>=1.6.0'
         version: 1.6.0(@pipecat-ai/client-js@1.13.0)
+      '@pipecat-ai/livekit-transport':
+        specifier: ^1.0.0
+        version: 1.0.0(@pipecat-ai/client-js@1.13.0)(@types/dom-mediacapture-record@1.0.22)
       '@pipecat-ai/moq-transport':
         specifier: ^0.1.0
         version: 0.1.0(@pipecat-ai/client-js@1.13.0)(@svta/cml-utils@1.5.0)(@types/react@19.1.11)(react@19.2.1)(zod@4.4.3)
@@ -2960,7 +2963,7 @@ packages:
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: '>=6.4.2'
+      vite: '>=7.3.2 <8.0.0'
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -10352,7 +10355,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -10372,7 +10375,7 @@ snapshots:
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.34.0(jiti@2.6.1))
@@ -10406,7 +10409,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10421,7 +10424,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10447,7 +10450,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10476,7 +10479,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
This adds support for the upcoming addition of the new LiveKit Transport. packaging changes are temporary and part of their own commit to be untangled once the transport is released. I will not merge this until that has happened and packaging has been updated accordingly.

Corresponding PRs:

New Livekit client-side Transport PRs:
- https://github.com/pipecat-ai/pipecat-client-web-transports/pull/86
- https://github.com/monster-anshu/pipecat-client-web-transports/pull/7

Corresponding Server fixes for LiveKit Transport:
- https://github.com/pipecat-ai/pipecat/pull/5297

Pipecat Prebuilt:
https://github.com/pipecat-ai/pipecat-prebuilt/pull/52