### PR TITLE
fix: dedupe bot output events in the events panel, pin pnpm version

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.14.0",
   "workspaces": [
     "package",
     "docs",

--- a/package/src/components/panels/EventsPanel.tsx
+++ b/package/src/components/panels/EventsPanel.tsx
@@ -33,7 +33,7 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottom = useRef(true);
   /** Last logged spoken status, keyed by bot output segment. */
-  const botOutputStatuses = useRef(new Map<string, string>());
+  const [botOutputStatuses] = useState(() => new Map<string, string>());
 
   const addEvent = useCallback((data: EventData) => {
     if (scrollRef.current) {
@@ -119,8 +119,8 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
     const status = data.spoken_status ?? (data.spoken ? "completed" : "new");
     if (data.segment_id !== undefined) {
       const key = String(data.segment_id);
-      if (botOutputStatuses.current.get(key) === status) return;
-      botOutputStatuses.current.set(key, status);
+      if (botOutputStatuses.get(key) === status) return;
+      botOutputStatuses.set(key, status);
     }
 
     const willBeSpoken = data.will_be_spoken ?? data.spoken;
@@ -138,6 +138,7 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
   });
 
   useRTVIClientEvent(RTVIEvent.Connected, () => {
+    botOutputStatuses.clear();
     addEvent({
       event: RTVIEvent.Connected,
       message: "Client connected",
@@ -145,7 +146,7 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
     });
   });
   useRTVIClientEvent(RTVIEvent.Disconnected, () => {
-    botOutputStatuses.current.clear();
+    botOutputStatuses.clear();
     addEvent({
       event: RTVIEvent.Disconnected,
       message: "Client disconnected",

--- a/package/src/components/panels/EventsPanel.tsx
+++ b/package/src/components/panels/EventsPanel.tsx
@@ -32,6 +32,8 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const isScrolledToBottom = useRef(true);
+  /** Last logged spoken status, keyed by bot output segment. */
+  const botOutputStatuses = useRef(new Map<string, string>());
 
   const addEvent = useCallback((data: EventData) => {
     if (scrollRef.current) {
@@ -108,9 +110,29 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
 
   useRTVIClientEvent(RTVIEvent.BotOutput, (data: BotOutputData) => {
     if (data.aggregated_by === "word") return;
+
+    // Servers on RTVI 2.0.0+ re-emit a segment's bot-output on every spoken
+    // progress update (roughly once per TTS word), so log a segment only when
+    // its spoken status actually changes instead of once per update. Those
+    // repeats always carry a segment_id; without one there is nothing safe to
+    // dedupe against, since two separate responses can share the same text.
+    const status = data.spoken_status ?? (data.spoken ? "completed" : "new");
+    if (data.segment_id !== undefined) {
+      const key = String(data.segment_id);
+      if (botOutputStatuses.current.get(key) === status) return;
+      botOutputStatuses.current.set(key, status);
+    }
+
+    const willBeSpoken = data.will_be_spoken ?? data.spoken;
+    const details = [
+      data.aggregated_by ?? "unknown",
+      data.segment_id !== undefined ? `#${data.segment_id}` : null,
+      willBeSpoken === false ? "not spoken" : `spoken: ${status}`,
+    ].filter(Boolean);
+
     addEvent({
       event: RTVIEvent.BotOutput,
-      message: `Bot output (${data.aggregated_by}, spoken: ${data.spoken}): ${data.text}`,
+      message: `Bot output (${details.join(", ")}): ${data.text}`,
       time: new Date().toLocaleTimeString(),
     });
   });
@@ -123,6 +145,7 @@ export const EventsPanel: React.FC<Props> = ({ collapsed = false }) => {
     });
   });
   useRTVIClientEvent(RTVIEvent.Disconnected, () => {
+    botOutputStatuses.current.clear();
     addEvent({
       event: RTVIEvent.Disconnected,
       message: "Client disconnected",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
+# Package manager settings live in the `pnpm` field of package.json: 30
+# security `overrides`, the `image-size` patch under `patchedDependencies`, and
+# `auditConfig`. pnpm 11 no longer reads that field at all — it ignores every
+# one of them with a single warning line and regenerates the lockfile without
+# them. `packageManager: pnpm@10.14.0` in package.json is what currently keeps
+# that from happening. Whenever this repo moves to pnpm 11, those three blocks
+# have to move into this file in the same change.
+
 packages:
   - package/
   - docs/


### PR DESCRIPTION
## Bot output events flood the Console events panel

The events panel logged one row per `bot-output` event. Servers on RTVI 2.0.0+ re-emit a segment's `bot-output` on **every spoken progress update** — roughly once per TTS word — so a four-sentence greeting produced ~40 near-identical rows. Every row also read `spoken: undefined`, because the handler used the `spoken` field, which is deprecated and only present on protocol 1.4.x.

Now the panel tracks the last logged spoken status per `segment_id` and logs only when it actually changes, and reads `will_be_spoken` / `spoken_status`. The deprecated field is kept as a fallback so 1.4.x servers still render correctly.

Same greeting, before and after:

```
# before — ~40 rows
Bot output (sentence, spoken: false): I'm your helpful AI assistant, here to make things easier for you.
Bot output (sentence, spoken: undefined): I'm your helpful AI assistant, here to make things easier for you.
Bot output (sentence, spoken: undefined): I'm your helpful AI assistant, here to make things easier for you.
... x30 more

# after — one row per state transition
Bot output (sentence, #271, spoken: new): I'm your helpful AI assistant, here to answer your questions...
Bot output (sentence, #271, spoken: in-progress): I'm your helpful AI assistant, here to answer your questions...
Bot output (sentence, #271, spoken: completed): I'm your helpful AI assistant, here to answer your questions...
```

Segments interleave (`#271 new`, `#299 new`, then `#271 in-progress`) because `new` fires when the sentence is aggregated off the LLM stream while the spoken states track TTS playback. That was always happening — it was just buried before.

### Scope of the deduplication

Dedupe applies **only to events that carry a `segment_id`**, and never keys on the event text. Two separate responses can legitimately share the same wording, and collapsing those would silently drop a real event from the log.

That costs nothing in coverage, because the repeats being collapsed are a 2.0.0+ phenomenon that always carries a segment id:

- The flood originates in `_handle_aggregated_progress` (`rtvi/observer.py`), which returns early for legacy clients — *"1.4.x clients use the old separate bot-output-progress event which was never released, so progress events are simply not sent to legacy clients."* A 1.4.x client gets at most one or two `bot-output` events per segment.
- Both the legacy and v2 paths go through `_send_aggregated_llm_text`, which sets `segment_id=frame.id` unconditionally. `BotOutputMessageData` marks `spoken` as **(v1 only)** and `will_be_spoken` / `spoken_status` as **(v2+)**, but `segment_id` carries no version marker because it is present in both.

So on a pipecat server every event that could be deduped has a segment id, and the guard is defensive against other RTVI implementations rather than covering a reachable pipecat case.

## Pin the pnpm version

Unrelated toolchain fix, found while working on the above.

CI pins pnpm to `10.14.0` in four workflow files, but nothing pinned it locally. pnpm 11 no longer reads the `pnpm` field from `package.json`, so running `pnpm install` with pnpm 11 silently ignored all 30 security overrides and the `image-size` patch, then regenerated the lockfile without them — reintroducing vulnerable transitive versions (e.g. `esbuild@0.25.12` and `0.27.7`, which the `esbuild@>=0.17.0 <0.28.1` override exists to prevent). The only signal was one easily-missed warning line.

Adding `packageManager` fixes this: pnpm reads the field and self-switches to the pinned version, so the repo resolves identically regardless of which pnpm a contributor has installed globally. No Corepack setup needed — verified that pnpm 11.23.0 reports `10.14.0` inside the repo.

The overrides stay in `package.json`, matching the existing layout. One cosmetic consequence: while a contributor's global pnpm is v11, its launcher prints the "pnpm field is no longer read" warning before handing off to the pinned 10.14.0. The version that actually runs is correct, so resolution is unaffected.

## Testing

- `pnpm install` and `pnpm build` pass; `pnpm-lock.yaml` unchanged.
- Overrides and patch confirmed applied: `esbuild@0.28.1`, `image-size@2.0.2_patch_hash=0aeb7ef…`.
- Events panel output verified against a live bot on protocol 2.1.0 (see above).
- eslint clean, no new type errors, `commitlint --from main --to HEAD` passes.

## Follow-up, not included

The pnpm version is now pinned in five places — `package.json` plus a hardcoded `version: 10.14.0` in `build.yml`, `lint-commits.yml`, `publish.yml`, and `release-please.yml`. `pnpm/action-setup@v4` can read `packageManager` directly if the `version:` lines are dropped, collapsing that to one source of truth. Left out of this PR since two of those workflows publish releases.
